### PR TITLE
Big version changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Since it's cross-platform I will not provide download links otherwise I will blo
 
 | Name | Version |
 |------|---------|
-| JDK / OpenJDK | 8 / 8 |
-| Maven | ≥ 3.6.1 |
-| MySQL | 5.7 |
+| JDK / OpenJDK | 15 / 15 |
+| Maven | ≥ 3.6.3 |
+| MySQL | 8.0 |
 | Any Java capable IDE [^1] | Any Version |
 | Fantasy Tennis Thai | 1.706 |
 
@@ -81,7 +81,9 @@ mvn clean install
 
 Before you run it the first time, please execute[^2] the SQL file **_create_fantasytennis.sql_** located inside **sql/create/**.
 
-Then you run the emulator via:
+Then edit applications.properties and change spring.jpa.hibernate.ddl-auto=update to spring.jpa.hibernate.ddl-auto=create. Make sure you change it back after the first start!
+
+Build the emulator and run it via:
 ```
 cd target
 java -jar ft_server_emulator.jar
@@ -95,7 +97,7 @@ When it says
 Then the initialization was successful and the server is running.
 
 Before you start to play, you have to do 3 more things:
-1. Execute[^2] the SQL file **__gameservertype.sql__** located inside **sql/insert/**
+1. Execute[^2] the SQL file **__gameservertype.sql__** located inside **sql/insert/** (execute this first!)
 2. Execute[^2] the SQL file **__gameserver.sql__** located inside **sql/insert/**
 3. Create[^2] an account inside the Account table. e.g: ```INSERT INTO `fantasytennis`.`Account`(`ap`, `gameMaster`, `password`, `status`, `username`) VALUES (0, b'1', 'test', 0, 'test');```
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.12.RELEASE</version>
+        <version>2.3.8.RELEASE</version>
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>15</java.version>
     </properties>
 
     <repositories>
@@ -53,22 +53,32 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.39</version>
+            <version>8.0.22</version>
         </dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.javassist</groupId>
+			<artifactId>javassist</artifactId>
+			<version>3.27.0-GA</version>
+		</dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-envers</artifactId>
-            <version>5.3.15.Final</version>
+            <version>5.4.27.Final</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.18</version>
+            <version>1.18.16</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
+            <version>3.11</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -78,12 +88,12 @@
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
-            <version>1.1.6</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
-            <groupId>dom4j</groupId>
+            <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>1.6.1</version>
+            <version>2.1.3</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/fantasytennis?autoReconnect=true&useSSL=false
 spring.datasource.username=jftse
 spring.datasource.password=jftse
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
 server.error.whitelabel.enabled=false


### PR DESCRIPTION
- Java JDK 8 to 15
- Springboot 2.1.12 to 2.3.8
- mysql-connector-java 5.1.39 to 8.0.22
- hibernate-envers 5.3.15 to 5.4.27
- lombok 1.16.18 to 1.18.16
- commons-lang3 3.8.1 to 3.11
- jaxen 1.1.6 to 1.2.0
- dom4j 1.6.1 to 2.1.3
MySQL changed from 5 to 8.
Switched the driver class in application.properties order to make it work with the new versions installed.
Switched the database platforming in application.properties to use mysql 8 dialect.
Edited README to use the new dependencies. Added some minor hints and tips for beginners to build and run their own emulator.