### PR TITLE
cap messenger list packets at 128 entries

### DIFF
--- a/chat-server/src/main/java/com/jftse/emulator/server/core/packets/messenger/S2CMessageListAnswerPacket.java
+++ b/chat-server/src/main/java/com/jftse/emulator/server/core/packets/messenger/S2CMessageListAnswerPacket.java
@@ -14,7 +14,9 @@ public class S2CMessageListAnswerPacket extends Packet {
 
         this.write(listType);
 
-        this.write((byte) messageList.size());
+        int size = Math.min(messageList.size(), 128);
+        messageList = messageList.subList(0, size);
+        this.write((byte) size);
         for (AbstractMessage am : messageList) {
             if (am instanceof Message m) {
                 this.write(Math.toIntExact(m.getId()));

--- a/game-server/src/main/java/com/jftse/emulator/server/core/packets/messenger/S2CMessageListAnswerPacket.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/packets/messenger/S2CMessageListAnswerPacket.java
@@ -14,7 +14,9 @@ public class S2CMessageListAnswerPacket extends Packet {
 
         this.write(listType);
 
-        this.write((byte) messageList.size());
+        int size = Math.min(messageList.size(), 128);
+        messageList = messageList.subList(0, size);
+        this.write((byte) size);
         for (AbstractMessage am : messageList) {
             if (am instanceof Message m) {
                 this.write(Math.toIntExact(m.getId()));


### PR DESCRIPTION
## Summary

Caps Messenger list responses to the first 128 entries in the existing chat-server and game-server packet serializers. The written count now matches the entries actually serialized, preserving the existing ascending order while avoiding byte-count overflow for larger histories.

## Scope

- Update the existing chat-server packet serializer.
- Update the existing game-server packet serializer.
- No paging, repository, service, handler, worker, shared-serializer, or new test-file changes.

## Validation

- Full Maven reactor through game-server and chat-server: `BUILD SUCCESS`.
- Direct checks against both serializers with 256 entries: count 128, bodies 128, IDs 1 through 128, no trailing bytes.
- `git diff --check` passes.