### PR TITLE
Add opt-in Thai-to-English chat translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 * [Project structure](#project-structure)
 * [Installation](#installation)
 * [Running the emulator](#running-the-emulator)
+* [Optional English chat translation](#optional-english-chat-translation)
 * [Reporting issues](#reporting-issues)
 * [Submitting fixes](#submitting-fixes)
 * [Copyright](#copyright)
@@ -16,7 +17,7 @@
 
 ## Introduction
 
-**JFTSE** is an open source project for the game **Fantasy Tennis**.    
+**JFTSE** is an open source project for the game **Fantasy Tennis**.
 
 It's a server emulator and written in Java.
 
@@ -38,7 +39,7 @@ Since it's cross-platform I will not provide download links otherwise I will blo
 
 * Also you need a Git CLI or GUI. Doesn't matter which one.
 
-**_Note:_** If under Windows, Maven & JDK has to be configured in your PATH variable. 
+**_Note:_** If under Windows, Maven & JDK has to be configured in your PATH variable.
 
 ## Project structure
 
@@ -92,7 +93,7 @@ sudo service docker status
 For downloading and installing RabbitMQ on your host, please refer to the official documentation: [ Downloading and Installing RabbitMQ
 — RabbitMQ](https://www.rabbitmq.com/download.html)
 
-We **recommend** using the docker image for RabbitMQ, since it's the easiest way to get it up and running.  
+We **recommend** using the docker image for RabbitMQ, since it's the easiest way to get it up and running.
 You can find the docker setup in the **docker** folder of the root project directory. There is a **docker-compose.yml** file which contains the configuration for the RabbitMQ server. The subfolder **rabbitmq** contains the configuration files and the **Dockerfile** for the RabbitMQ server.
 
 #### Building the RabbitMQ server
@@ -113,13 +114,13 @@ The RabbitMQ server is now running and is reachable through port 5672 and the 15
 
 #### Configuring the RabbitMQ server
 
-It is recommended to adjust the **definitions.json** file in the **rabbitmq** folder inside the **docker** folder of the root project directory.  
+It is recommended to adjust the **definitions.json** file in the **rabbitmq** folder inside the **docker** folder of the root project directory.
 The file contains configuration for users, vhosts and permissions (refer to official documentation for all available options). Currently the default configuration is used, which is **not recommended for production use**.
 
-Therefore you should adjust the configuration to your needs. Getting a hashed password for a user is easy and can be done inside the rabbitmq container.  
+Therefore you should adjust the configuration to your needs. Getting a hashed password for a user is easy and can be done inside the rabbitmq container.
 First you need to connect to your running rabbitmq container:
 ```
-docker exec -it rabbitmq-server bash
+docker compose exec rabbitmq bash
 ```
 Then you can use the **rabbitmqctl** command to generate a hashed password for a user:
 ```
@@ -128,7 +129,7 @@ rabbitmqctl hash_password <password>
 
 With **CTRL + C** or typing **exit** you can exit the container.
 
-The output of the command is the hashed password, which you can use in the **definitions.json** file.  
+The output of the command is the hashed password, which you can use in the **definitions.json** file.
 That same password and username (defined in **definitions.json**) has to be used in the **application.properties** file of the **chat-server** and **game-server** module. The host and port inside **application.properties** has not to be adjusted unless you changed the host and port configuration of the RabbitMQ server.
 
 You need to restart the RabbitMQ server after you adjusted the **definitions.json** file:
@@ -179,8 +180,8 @@ java -jar auth-server-1.0.0-SNAPSHOT.jar -import
 ```
 Or you run it from inside your Java IDE if using one. Make sure to add the **-import** argument.
 
-The auth-server will do his first time initialization and the process will take some time. It loades static data like products of the shop etc.    
-When it says 
+The auth-server will do his first time initialization and the process will take some time. It loades static data like products of the shop etc.
+When it says
 > **auth-server successfully started!**
 
 Then the initialization was successful and the auth-server is running. You can now close it and start it again without the **-import** argument.
@@ -188,7 +189,7 @@ Then the initialization was successful and the auth-server is running. You can n
 java -jar auth-server-1.0.0-SNAPSHOT.jar
 ```
 
-Before you start playing, you need to import additional data into the database.  
+Before you start playing, you need to import additional data into the database.
 **Run the `import_sql.sh` script** located inside the `scripts/` folder to insert required game data:
    ```sh
    cd <path to the cloned project>/scripts
@@ -217,6 +218,100 @@ cd xxx-server/target
 java -jar xxx-server-1.0.0-SNAPSHOT.jar
 ```
 
+## Optional English chat translation
+
+JFTSE can translate incoming lobby, room, and team chat to English independently
+for each recipient. Translation is off by default.
+
+This is an optional quality-of-life feature for the current Fantasy Tennis community:
+many active players speak Thai, and opt-in translation makes mixed Thai/English lobbies
+and matches easier to enjoy together without changing chat for anyone who leaves it
+disabled.
+
+Players control their own preference from chat:
+
+```
+-translate on
+-translate off
+```
+
+The command accepts surrounding whitespace and case differences. A missing or
+unsupported argument returns usage without changing the saved preference. Command
+messages are not broadcast. The preference is stored on the `Player` record and is
+restored at the next login.
+
+Delivery rules:
+
+* The sender always receives the original message.
+* Recipients who did not opt in receive the original message.
+* Opted-in recipients receive English when translation succeeds.
+* Room and team visibility rules are unchanged.
+* Provider errors, timeouts, malformed responses, and capacity limits fall back to
+  the original message instead of dropping or reordering chat.
+* Oversized input is not sent to the provider, and provider output is bounded before
+  it is placed in a game packet.
+
+Operators enable the feature with the deployment environment:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CHAT_TRANSLATION_ENABLED` | `false` | Enables provider requests. |
+| `CHAT_TRANSLATION_TIMEOUT_MS` | `450` | Per-request timeout. |
+| `CHAT_TRANSLATION_MAX_INPUT_CHARS` | `256` | Largest source message sent to the provider. |
+| `CHAT_TRANSLATION_MAX_TRANSLATED_CHARS` | `1024` | Largest translated packet payload. |
+| `CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS` | `8` | Shared provider concurrency limit. |
+
+The Compose deployment supplies the internal provider endpoint. Its provider image
+pins the LibreTranslate base manifest plus exact English/Thai Argos and MiniSBD model
+artifacts by SHA-256, disables automatic model updates, and must pass a real
+Thai-to-English `/translate` health probe before starting the emulator:
+
+```sh
+cd docker
+CHAT_TRANSLATION_ENABLED=true docker compose up -d --build
+```
+
+No paid translation API or external cloud translation account is required. Internet
+access is needed when Docker first pulls/builds the images and downloads the pinned
+model artifacts. Normal runtime translation stays inside the Compose network, and the
+built provider image does not download models or mutable model indexes at startup.
+
+On a fresh database, the one-shot `database-fixtures` service waits for Hibernate's
+schema and imports the canonical SQL fixtures. It should finish with exit code `0`.
+LibreTranslate should report `healthy`, and all four programs should report `RUNNING`:
+
+```sh
+docker compose ps -a
+docker compose exec emulator supervisorctl status
+```
+
+### Memory guidance
+
+The exact all-in-one Compose deployment was measured on Linux after a fresh startup.
+These are observed values, not hard limits:
+
+| Component | Idle | After translation load |
+|-----------|------|------------------------|
+| LibreTranslate | 763 MiB | 764 MiB (773 MiB observed peak) |
+| Emulator (four JVMs) | 3.10 GiB | 3.16 GiB |
+| MySQL | 469 MiB | 469 MiB |
+| RabbitMQ | 144 MiB | 180 MiB |
+| **Running-service total** | **about 4.45 GiB** | **about 4.54 GiB** |
+
+The translation feature therefore added about **0.75 GiB** in this measurement.
+Reserve **1 GiB** for LibreTranslate to allow normal variation. For the complete
+all-in-one Compose stack, an **8 GiB host is the practical minimum recommendation** so
+the operating system, Docker, and temporary JVM/database growth retain headroom.
+Player count, traffic, kernel caching, Docker version, and JVM behavior can change
+actual usage, so production operators should still monitor their own host.
+
+Model or provider upgrades are deliberate deployment changes: update the pinned base
+digest, artifact URLs, and SHA-256 values in `docker/libretranslate/Dockerfile`, then
+verify the concrete Thai-to-English health probe before rollout. Models are installed
+at image build time; a fresh runtime does not download mutable model indexes. When
+translation is enabled, source chat may be sent to the configured translation provider
+for opted-in recipients.
+
 ## Running client
 1. Download FT Client from : https://www.jftse.com/client/FantaTennis.7z
 2. Unzip and execute it for the first time in order to create configuration files
@@ -233,7 +328,7 @@ _TODO_
 
 ## Copyright
 
-License: GPL 3.0    
+License: GPL 3.0
 Read file [LICENSE](LICENSE).
 
 ## Footnotes

--- a/README.md
+++ b/README.md
@@ -327,6 +327,35 @@ the configured capacity keep the original chat message instead of blocking gamep
 Operators using a different or multi-worker provider should benchmark before increasing
 `CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS`.
 
+#### What 100 concurrent players means
+
+Connected players are not the provider load unit. Inside one game or chat server
+process, a single Thai chat message broadcast to 100 opted-in recipients is coalesced
+by exact message text and makes **one provider request**, not 100. All recipients share
+that in-flight result, and later repeats can use the process's 512-entry translation
+cache.
+
+Game and chat are separate Java processes, so each owns its own limit and cache while
+sharing the same LibreTranslate container. If both process distinct messages at their
+default limit simultaneously, the provider can see up to four requests. A constrained
+host that expects heavy activity on both can set
+`CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS=1`, limiting the combined admission to two.
+
+Provider capacity is governed by the rate of **unique untranslated messages**. As a
+simple steady-state illustration, 100 players each sending one unique Thai message
+every ten seconds is 10 requests per second, below the measured 17.7 requests per
+second on the test host. One message every five seconds each is 20 requests per second
+and exceeds that single-instance measurement. Real results vary with message reuse,
+burstiness, CPU, and model behavior.
+
+Inside one server process, an artificial instant burst of 100 unique Thai messages does
+not queue stale chat: the configured two requests start translation and the other 98
+immediately keep their original text. Per-recipient message order is still preserved.
+This fail-open behavior keeps gameplay responsive; it means translation is best-effort
+during overload, not a guaranteed delivery service. Communities that require every
+unique burst message to be translated should benchmark and horizontally scale the
+provider rather than simply raising concurrency on one CPU-bound instance.
+
 Model or provider upgrades are deliberate deployment changes: update the pinned base
 digest, artifact URLs, and SHA-256 values in `docker/libretranslate/Dockerfile`, then
 verify the concrete Thai-to-English health probe before rollout. Models are installed

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Operators enable the feature with the deployment environment:
 | `CHAT_TRANSLATION_TIMEOUT_MS` | `450` | Per-request timeout. |
 | `CHAT_TRANSLATION_MAX_INPUT_CHARS` | `256` | Largest source message sent to the provider. |
 | `CHAT_TRANSLATION_MAX_TRANSLATED_CHARS` | `1024` | Largest translated packet payload. |
-| `CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS` | `8` | Shared provider concurrency limit. |
+| `CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS` | `2` | Shared provider concurrency limit. |
 
 The Compose deployment supplies the internal provider endpoint. Its provider image
 pins the LibreTranslate base manifest plus exact English/Thai Argos and MiniSBD model
@@ -304,6 +304,28 @@ all-in-one Compose stack, an **8 GiB host is the practical minimum recommendatio
 the operating system, Docker, and temporary JVM/database growth retain headroom.
 Player count, traffic, kernel caching, Docker version, and JVM behavior can change
 actual usage, so production operators should still monitor their own host.
+
+### Concurrent translation performance
+
+The bundled provider was also measured with three rounds of 30 unique Thai messages
+per concurrency level. Every measured request returned a non-empty English response:
+
+| Concurrent requests | Throughput | Mean | p95 | Maximum |
+|---------------------|------------|------|-----|---------|
+| 1 | 17.75 req/s | 47.7 ms | 72.9 ms | 99.0 ms |
+| 2 | 17.72 req/s | 100.9 ms | 157.9 ms | 217.4 ms |
+| 4 | 10.72 req/s | 355.4 ms | 822.3 ms | 1010.7 ms |
+| 8 | 10.69 req/s | 654.6 ms | 1266.6 ms | 1984.9 ms |
+| 16 | 10.67 req/s | 1168.9 ms | 2107.4 ms | 2967.9 ms |
+
+The bundled image is CPU-bound and behaves like a one-worker provider for unique
+messages. The default limit is therefore **2 concurrent provider requests**: it keeps
+essentially the same throughput as one request while allowing two messages to progress,
+and stayed within the default 450 ms timeout on the measured host. Completed
+translations are cached, identical in-flight requests are coalesced, and requests above
+the configured capacity keep the original chat message instead of blocking gameplay.
+Operators using a different or multi-worker provider should benchmark before increasing
+`CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS`.
 
 Model or provider upgrades are deliberate deployment changes: update the pinned base
 digest, artifact URLs, and SHA-256 values in `docker/libretranslate/Dockerfile`, then

--- a/README.md
+++ b/README.md
@@ -220,13 +220,8 @@ java -jar xxx-server-1.0.0-SNAPSHOT.jar
 
 ## Optional English chat translation
 
-JFTSE can translate incoming lobby, room, and team chat to English independently
-for each recipient. Translation is off by default.
-
-This is an optional quality-of-life feature for the current Fantasy Tennis community:
-many active players speak Thai, and opt-in translation makes mixed Thai/English lobbies
-and matches easier to enjoy together without changing chat for anyone who leaves it
-disabled.
+JFTSE can translate Thai lobby, room, and team chat to English for players who opt in.
+Translation is off by default.
 
 Players control their own preference from chat:
 
@@ -235,133 +230,29 @@ Players control their own preference from chat:
 -translate off
 ```
 
-The command accepts surrounding whitespace and case differences. A missing or
-unsupported argument returns usage without changing the saved preference. Command
-messages are not broadcast. The preference is stored on the `Player` record and is
-restored at the next login.
+The preference is saved per player. Senders and players who leave translation disabled
+receive the original message. Translation failures also fall back to the original
+message without delaying or reordering chat.
 
-Delivery rules:
-
-* The sender always receives the original message.
-* Recipients who did not opt in receive the original message.
-* Opted-in recipients receive English when translation succeeds.
-* Room and team visibility rules are unchanged.
-* Provider errors, timeouts, malformed responses, and capacity limits fall back to
-  the original message instead of dropping or reordering chat.
-* Oversized input is not sent to the provider, and provider output is bounded before
-  it is placed in a game packet.
-
-Operators enable the feature with the deployment environment:
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `CHAT_TRANSLATION_ENABLED` | `false` | Enables provider requests. |
-| `CHAT_TRANSLATION_TIMEOUT_MS` | `450` | Per-request timeout. |
-| `CHAT_TRANSLATION_MAX_INPUT_CHARS` | `256` | Largest source message sent to the provider. |
-| `CHAT_TRANSLATION_MAX_TRANSLATED_CHARS` | `1024` | Largest translated packet payload. |
-| `CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS` | `2` | Shared provider concurrency limit. |
-
-The Compose deployment supplies the internal provider endpoint. Its provider image
-pins the LibreTranslate base manifest plus exact English/Thai Argos and MiniSBD model
-artifacts by SHA-256, disables automatic model updates, and must pass a real
-Thai-to-English `/translate` health probe before starting the emulator:
+The Docker deployment includes a self-hosted LibreTranslate provider. Enable it with:
 
 ```sh
 cd docker
 CHAT_TRANSLATION_ENABLED=true docker compose up -d --build
 ```
 
-No paid translation API or external cloud translation account is required. Internet
-access is needed when Docker first pulls/builds the images and downloads the pinned
-model artifacts. Normal runtime translation stays inside the Compose network, and the
-built provider image does not download models or mutable model indexes at startup.
+Configuration:
 
-On a fresh database, the one-shot `database-fixtures` service waits for Hibernate's
-schema and imports the canonical SQL fixtures. It should finish with exit code `0`.
-LibreTranslate should report `healthy`, and all four programs should report `RUNNING`:
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CHAT_TRANSLATION_ENABLED` | `false` | Enables translation. |
+| `CHAT_TRANSLATION_TIMEOUT_MS` | `450` | Per-request timeout. |
+| `CHAT_TRANSLATION_MAX_INPUT_CHARS` | `256` | Maximum source length. |
+| `CHAT_TRANSLATION_MAX_TRANSLATED_CHARS` | `1024` | Maximum translated length. |
+| `CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS` | `2` | Per-server provider concurrency. |
 
-```sh
-docker compose ps -a
-docker compose exec emulator supervisorctl status
-```
-
-### Memory guidance
-
-The exact all-in-one Compose deployment was measured on Linux after a fresh startup.
-These are observed values, not hard limits:
-
-| Component | Idle | After translation load |
-|-----------|------|------------------------|
-| LibreTranslate | 763 MiB | 764 MiB (773 MiB observed peak) |
-| Emulator (four JVMs) | 3.10 GiB | 3.16 GiB |
-| MySQL | 469 MiB | 469 MiB |
-| RabbitMQ | 144 MiB | 180 MiB |
-| **Running-service total** | **about 4.45 GiB** | **about 4.54 GiB** |
-
-The translation feature therefore added about **0.75 GiB** in this measurement.
-Reserve **1 GiB** for LibreTranslate to allow normal variation. For the complete
-all-in-one Compose stack, an **8 GiB host is the practical minimum recommendation** so
-the operating system, Docker, and temporary JVM/database growth retain headroom.
-Player count, traffic, kernel caching, Docker version, and JVM behavior can change
-actual usage, so production operators should still monitor their own host.
-
-### Concurrent translation performance
-
-The bundled provider was also measured with three rounds of 30 unique Thai messages
-per concurrency level. Every measured request returned a non-empty English response:
-
-| Concurrent requests | Throughput | Mean | p95 | Maximum |
-|---------------------|------------|------|-----|---------|
-| 1 | 17.75 req/s | 47.7 ms | 72.9 ms | 99.0 ms |
-| 2 | 17.72 req/s | 100.9 ms | 157.9 ms | 217.4 ms |
-| 4 | 10.72 req/s | 355.4 ms | 822.3 ms | 1010.7 ms |
-| 8 | 10.69 req/s | 654.6 ms | 1266.6 ms | 1984.9 ms |
-| 16 | 10.67 req/s | 1168.9 ms | 2107.4 ms | 2967.9 ms |
-
-The bundled image is CPU-bound and behaves like a one-worker provider for unique
-messages. The default limit is therefore **2 concurrent provider requests**: it keeps
-essentially the same throughput as one request while allowing two messages to progress,
-and stayed within the default 450 ms timeout on the measured host. Completed
-translations are cached, identical in-flight requests are coalesced, and requests above
-the configured capacity keep the original chat message instead of blocking gameplay.
-Operators using a different or multi-worker provider should benchmark before increasing
-`CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS`.
-
-#### What 100 concurrent players means
-
-Connected players are not the provider load unit. Inside one game or chat server
-process, a single Thai chat message broadcast to 100 opted-in recipients is coalesced
-by exact message text and makes **one provider request**, not 100. All recipients share
-that in-flight result, and later repeats can use the process's 512-entry translation
-cache.
-
-Game and chat are separate Java processes, so each owns its own limit and cache while
-sharing the same LibreTranslate container. If both process distinct messages at their
-default limit simultaneously, the provider can see up to four requests. A constrained
-host that expects heavy activity on both can set
-`CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS=1`, limiting the combined admission to two.
-
-Provider capacity is governed by the rate of **unique untranslated messages**. As a
-simple steady-state illustration, 100 players each sending one unique Thai message
-every ten seconds is 10 requests per second, below the measured 17.7 requests per
-second on the test host. One message every five seconds each is 20 requests per second
-and exceeds that single-instance measurement. Real results vary with message reuse,
-burstiness, CPU, and model behavior.
-
-Inside one server process, an artificial instant burst of 100 unique Thai messages does
-not queue stale chat: the configured two requests start translation and the other 98
-immediately keep their original text. Per-recipient message order is still preserved.
-This fail-open behavior keeps gameplay responsive; it means translation is best-effort
-during overload, not a guaranteed delivery service. Communities that require every
-unique burst message to be translated should benchmark and horizontally scale the
-provider rather than simply raising concurrency on one CPU-bound instance.
-
-Model or provider upgrades are deliberate deployment changes: update the pinned base
-digest, artifact URLs, and SHA-256 values in `docker/libretranslate/Dockerfile`, then
-verify the concrete Thai-to-English health probe before rollout. Models are installed
-at image build time; a fresh runtime does not download mutable model indexes. When
-translation is enabled, source chat may be sent to the configured translation provider
-for opted-in recipients.
+No paid API or cloud account is required. The provider uses about 0.75 GiB of RAM in
+the measured deployment; reserve about 1 GiB for it.
 
 ## Running client
 1. Download FT Client from : https://www.jftse.com/client/FantaTennis.7z

--- a/auth-server/src/main/java/com/jftse/emulator/AuthServerStart.java
+++ b/auth-server/src/main/java/com/jftse/emulator/AuthServerStart.java
@@ -24,10 +24,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 import javax.annotation.PreDestroy;
+import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -49,7 +51,10 @@ public class AuthServerStart implements CommandLineRunner {
     private ServerConfService serverConfService;
 
     public static void main(String[] args) {
-        SpringApplication.run(AuthServerStart.class, args);
+        ConfigurableApplicationContext context = SpringApplication.run(AuthServerStart.class, args);
+        if (Arrays.stream(args).anyMatch("-import-only"::equalsIgnoreCase)) {
+            System.exit(SpringApplication.exit(context));
+        }
     }
 
     @Override

--- a/auth-server/src/main/java/com/jftse/emulator/server/module/DBDataLoader.java
+++ b/auth-server/src/main/java/com/jftse/emulator/server/module/DBDataLoader.java
@@ -102,6 +102,7 @@ public class DBDataLoader implements CommandLineRunner {
     private enum ECLIOption {
         EXPORT("-export"),
         IMPORT("-import"),
+        IMPORT_ONLY("-import-only"),
         NONE("");
 
         private final String option;
@@ -132,7 +133,7 @@ public class DBDataLoader implements CommandLineRunner {
             case EXPORT:
                 dbExporter.init();
                 return;
-            case IMPORT:
+            case IMPORT, IMPORT_ONLY:
                 break;
             case NONE:
                 return;

--- a/chat-server/server.conf
+++ b/chat-server/server.conf
@@ -31,4 +31,4 @@ ChatTranslationEndpoint=http://libretranslate:5000/translate
 ChatTranslationTimeoutMs=450
 ChatTranslationMaxInputChars=256
 ChatTranslationMaxTranslatedChars=1024
-ChatTranslationMaxConcurrentRequests=8
+ChatTranslationMaxConcurrentRequests=2

--- a/chat-server/server.conf
+++ b/chat-server/server.conf
@@ -23,3 +23,12 @@ UpdateMetricsInterval=15
 #
 # Interval (in minutes) between refreshing the lottery pool cache from the database
 LotteryPoolCacheRefreshInterval=10
+
+#
+# Translate Thai player chat for players who use "-translate on"
+ChatTranslationEnabled=false
+ChatTranslationEndpoint=http://libretranslate:5000/translate
+ChatTranslationTimeoutMs=450
+ChatTranslationMaxInputChars=256
+ChatTranslationMaxTranslatedChars=1024
+ChatTranslationMaxConcurrentRequests=8

--- a/chat-server/src/main/java/com/jftse/emulator/ChatServerStart.java
+++ b/chat-server/src/main/java/com/jftse/emulator/ChatServerStart.java
@@ -7,6 +7,8 @@ import com.jftse.server.core.StartupBanner;
 import com.jftse.server.core.YamlPropertySourceFactory;
 import com.jftse.server.core.protocol.PacketAutoRegister;
 import com.jftse.server.core.shared.ServerConfService;
+import com.jftse.server.core.translation.ChatTranslationServices;
+import com.jftse.server.core.translation.LibreTranslateTranslationService;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -30,6 +32,9 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 import javax.annotation.PreDestroy;
 import java.util.concurrent.ExecutionException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.concurrent.Future;
 
 @SpringBootApplication
@@ -82,6 +87,7 @@ public class ChatServerStart implements CommandLineRunner {
                 .childOption(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(32 * 1024, 128 * 1024)); // 32 KB low, 128 KB high
 
         final int port = serverConfService.get("ServerPort", Integer.class);
+        configureChatTranslation();
         b.bind(port).addListener(cf -> {
             if (cf.isSuccess()) {
                 serverLoop.start();
@@ -91,6 +97,32 @@ public class ChatServerStart implements CommandLineRunner {
                 log.error("Failed to start chat-server: {}", cf.cause().getMessage(), cf.cause());
             }
         });
+    }
+
+    private void configureChatTranslation() {
+        boolean enabled = serverConfService.get("ChatTranslationEnabled", Boolean.class, false);
+        int timeoutMs = serverConfService.get("ChatTranslationTimeoutMs", Integer.class, 450);
+        int maximumInputChars = serverConfService.get("ChatTranslationMaxInputChars", Integer.class, 256);
+        int maximumTranslatedChars = serverConfService.get("ChatTranslationMaxTranslatedChars", Integer.class, 1024);
+        int maximumConcurrentRequests = serverConfService.get("ChatTranslationMaxConcurrentRequests", Integer.class, 8);
+        URI endpoint = URI.create(serverConfService.get(
+                "ChatTranslationEndpoint",
+                String.class,
+                "http://libretranslate:5000/translate"
+        ));
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(timeoutMs))
+                .build();
+        ChatTranslationServices.configure(new LibreTranslateTranslationService(
+                httpClient,
+                endpoint,
+                Duration.ofMillis(timeoutMs),
+                enabled,
+                maximumInputChars,
+                maximumTranslatedChars,
+                maximumConcurrentRequests
+        ));
+        log.info("Thai-to-English chat translation is {}", enabled ? "enabled" : "disabled");
     }
 
     @PreDestroy

--- a/chat-server/src/main/java/com/jftse/emulator/ChatServerStart.java
+++ b/chat-server/src/main/java/com/jftse/emulator/ChatServerStart.java
@@ -104,7 +104,11 @@ public class ChatServerStart implements CommandLineRunner {
         int timeoutMs = serverConfService.get("ChatTranslationTimeoutMs", Integer.class, 450);
         int maximumInputChars = serverConfService.get("ChatTranslationMaxInputChars", Integer.class, 256);
         int maximumTranslatedChars = serverConfService.get("ChatTranslationMaxTranslatedChars", Integer.class, 1024);
-        int maximumConcurrentRequests = serverConfService.get("ChatTranslationMaxConcurrentRequests", Integer.class, 8);
+        int maximumConcurrentRequests = serverConfService.get(
+                "ChatTranslationMaxConcurrentRequests",
+                Integer.class,
+                LibreTranslateTranslationService.DEFAULT_MAX_CONCURRENT_REQUESTS
+        );
         URI endpoint = URI.create(serverConfService.get(
                 "ChatTranslationEndpoint",
                 String.class,

--- a/chat-server/src/main/java/com/jftse/emulator/server/core/command/CommandManager.java
+++ b/chat-server/src/main/java/com/jftse/emulator/server/core/command/CommandManager.java
@@ -5,6 +5,7 @@ import com.jftse.emulator.common.scripting.ScriptManagerV2;
 import com.jftse.emulator.common.utilities.StringUtils;
 import com.jftse.emulator.server.core.command.commands.gm.*;
 import com.jftse.emulator.server.core.command.commands.player.OpenGachaCommand;
+import com.jftse.emulator.server.core.command.commands.player.TranslateChatCommand;
 import com.jftse.emulator.server.core.life.script.ScriptContextHelper;
 import com.jftse.emulator.server.core.manager.GameManager;
 import com.jftse.emulator.server.core.packets.chat.S2CChatLobbyAnswerPacket;
@@ -67,11 +68,18 @@ public class CommandManager {
     }
 
     public boolean isCommand(String content) {
-        if (StringUtils.isEmpty(content) || content.isEmpty())
+        if (StringUtils.isEmpty(content))
             return false;
 
-        char heading = content.charAt(0);
-        return heading == COMMAND_HEADING && registeredCommands.get(getCommandArgumentList(content).get(0).substring(1)) != null;
+        List<String> arguments = getCommandArgumentList(content.trim());
+        if (arguments.isEmpty()) {
+            return false;
+        }
+
+        String commandToken = arguments.get(0);
+        return commandToken.length() > 1
+                && commandToken.charAt(0) == COMMAND_HEADING
+                && registeredCommands.containsKey(commandToken.substring(1).toLowerCase(Locale.ROOT));
     }
 
     public void handle(FTConnection connection, String content) {
@@ -94,10 +102,10 @@ public class CommandManager {
     }
 
     private void executeCommand(FTConnection connection, String content) {
-        List<String> commandArgumentList = getCommandArgumentList(content);
+        List<String> commandArgumentList = getCommandArgumentList(content.trim());
 
         String commandName = commandArgumentList.get(0);
-        commandName = commandName.substring(1);
+        commandName = commandName.substring(1).toLowerCase(Locale.ROOT);
 
         commandArgumentList.remove(0);
 
@@ -134,12 +142,13 @@ public class CommandManager {
     public void registerCommand(String commandName, int rank, AbstractCommand command) {
         command.setRank(rank);
         command.setCommandName(commandName);
-        registeredCommands.put(commandName, command);
+        registeredCommands.put(commandName.toLowerCase(Locale.ROOT), command);
         log.info("Registered command -" + commandName);
     }
 
     private void registerCommands() {
         registerCommand("og", 0, new OpenGachaCommand());
+        registerCommand("translate", 0, new TranslateChatCommand());
         registerCommand("ban", 1, new BanPlayerCommand());
         registerCommand("unban", 1, new UnbanPlayerCommand());
         registerCommand("sN", 1, new ServerNoticeCommand());

--- a/chat-server/src/main/java/com/jftse/emulator/server/core/command/commands/player/TranslateChatCommand.java
+++ b/chat-server/src/main/java/com/jftse/emulator/server/core/command/commands/player/TranslateChatCommand.java
@@ -1,0 +1,69 @@
+package com.jftse.emulator.server.core.command.commands.player;
+
+import com.jftse.emulator.server.core.command.AbstractCommand;
+import com.jftse.emulator.server.core.manager.ServiceManager;
+import com.jftse.emulator.server.core.packets.chat.S2CChatLobbyAnswerPacket;
+import com.jftse.emulator.server.core.packets.chat.S2CChatRoomAnswerPacket;
+import com.jftse.emulator.server.net.FTClient;
+import com.jftse.emulator.server.net.FTConnection;
+import com.jftse.entities.database.model.player.Player;
+import com.jftse.server.core.translation.ChatTranslationServices;
+import lombok.extern.log4j.Log4j2;
+
+import java.util.List;
+import java.util.Locale;
+
+@Log4j2
+public class TranslateChatCommand extends AbstractCommand {
+    public TranslateChatCommand() {
+        setDescription("Translate Thai player chat to English");
+    }
+
+    @Override
+    public void execute(FTConnection connection, List<String> params) {
+        FTClient client = connection.getClient();
+        if (client == null || !client.hasPlayer()) {
+            sendStatus(connection, "Translation preference requires an active player");
+            return;
+        }
+
+        if (params.size() != 1) {
+            sendStatus(connection, "Use -translate on or -translate off");
+            return;
+        }
+
+        String mode = params.get(0).toLowerCase(Locale.ROOT);
+        if (!mode.equals("on") && !mode.equals("off")) {
+            sendStatus(connection, "Use -translate on or -translate off");
+            return;
+        }
+
+        boolean enabled = mode.equals("on");
+        Player player = client.getPlayer().getPlayer();
+        Boolean previousPreference = player.getTranslateChatToEnglish();
+        player.setTranslateChatToEnglish(enabled);
+        try {
+            ServiceManager.getInstance().getPlayerService().save(player);
+        } catch (RuntimeException exception) {
+            player.setTranslateChatToEnglish(previousPreference);
+            log.error("Failed to save chat translation preference for player {}", player.getId(), exception);
+            sendStatus(connection, "Translation preference could not be saved");
+            return;
+        }
+        client.setTranslateChatToEnglish(enabled);
+
+        String message = "Thai to English chat translation " + (enabled ? "enabled" : "disabled");
+        if (enabled && !ChatTranslationServices.get().isEnabled()) {
+            message += " (server translation is currently disabled)";
+        }
+        sendStatus(connection, message);
+    }
+
+    private void sendStatus(FTConnection connection, String message) {
+        if (connection.getClient() != null && connection.getClient().getActiveRoom() != null) {
+            connection.sendTCP(new S2CChatRoomAnswerPacket((byte) 2, "Translation", message));
+        } else {
+            connection.sendTCP(new S2CChatLobbyAnswerPacket((char) 0, "Translation", message));
+        }
+    }
+}

--- a/chat-server/src/main/java/com/jftse/emulator/server/core/handler/chat/ChatMessageLobbyPacketHandler.java
+++ b/chat-server/src/main/java/com/jftse/emulator/server/core/handler/chat/ChatMessageLobbyPacketHandler.java
@@ -8,8 +8,11 @@ import com.jftse.server.core.handler.PacketHandler;
 import com.jftse.server.core.handler.PacketId;
 import com.jftse.server.core.shared.packets.chat.CMSGChatMessageLobby;
 import com.jftse.server.core.shared.packets.chat.SMSGChatMessageLobby;
+import com.jftse.server.core.translation.ChatTranslationServices;
+import com.jftse.server.core.translation.LibreTranslateTranslationService;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @PacketId(CMSGChatMessageLobby.PACKET_ID)
 public class ChatMessageLobbyPacketHandler implements PacketHandler<FTConnection, CMSGChatMessageLobby> {
@@ -37,6 +40,51 @@ public class ChatMessageLobbyPacketHandler implements PacketHandler<FTConnection
                 .filter(FTClient::isInLobby)
                 .toList();
 
-        clientList.forEach(c -> c.getConnection().sendTCP(chatLobbyMessage));
+        LibreTranslateTranslationService translationService = ChatTranslationServices.get();
+        clientList.forEach(recipient ->
+                sendMessage(recipient, client, chatLobbyReqPacket, translationService)
+        );
+    }
+
+    private static void sendMessage(
+            FTClient recipient,
+            FTClient sender,
+            CMSGChatMessageLobby request,
+            LibreTranslateTranslationService translationService
+    ) {
+        String senderName = sender.getPlayer().getName();
+        int textColor = sender.getTextMode();
+        long membershipGeneration = recipient.getLobbyMembershipGeneration();
+        recipient.getChatDelivery().enqueue(
+                messageForRecipient(sender, recipient, request.getMessage(), translationService),
+                message -> {
+                    FTConnection connection = recipient.getConnection();
+                    if (!recipient.isInLobby()
+                            || recipient.getLobbyMembershipGeneration() != membershipGeneration
+                            || connection == null) {
+                        return;
+                    }
+                    connection.sendTCP(
+                            SMSGChatMessageLobby.builder()
+                                    .unk(request.getUnk())
+                                    .sender(senderName)
+                                    .message(message)
+                                    .textColor(textColor)
+                                    .build()
+                    );
+                }
+        );
+    }
+
+    static CompletableFuture<String> messageForRecipient(
+            FTClient sender,
+            FTClient recipient,
+            String message,
+            LibreTranslateTranslationService translationService
+    ) {
+        if (recipient == sender || !recipient.isTranslateChatToEnglish()) {
+            return CompletableFuture.completedFuture(message);
+        }
+        return translationService.translateToEnglish(message);
     }
 }

--- a/chat-server/src/main/java/com/jftse/emulator/server/core/handler/chat/ChatMessageRoomPacketHandler.java
+++ b/chat-server/src/main/java/com/jftse/emulator/server/core/handler/chat/ChatMessageRoomPacketHandler.java
@@ -12,6 +12,11 @@ import com.jftse.server.core.handler.PacketHandler;
 import com.jftse.server.core.handler.PacketId;
 import com.jftse.server.core.shared.packets.chat.CMSGChatMessageRoom;
 import com.jftse.server.core.shared.packets.chat.SMSGChatMessageRoom;
+import com.jftse.server.core.translation.ChatTranslationServices;
+import com.jftse.server.core.translation.LibreTranslateTranslationService;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BooleanSupplier;
 
 @PacketId(CMSGChatMessageRoom.PACKET_ID)
 public class ChatMessageRoomPacketHandler implements PacketHandler<FTConnection, CMSGChatMessageRoom> {
@@ -56,16 +61,99 @@ public class ChatMessageRoomPacketHandler implements PacketHandler<FTConnection,
 
                 boolean playerCanSeeMessage = areInSameTeam(senderPos, rp.getPosition()) || rp.getPosition() == MiscConstants.InvisibleGmSlot;
                 if (c.hasPlayer() && rp.getPlayerId() == c.getPlayer().getId() && playerCanSeeMessage) {
-                    c.getConnection().sendTCP(chatRoomMessage);
+                    sendMessage(
+                            c,
+                            client,
+                            chatRoomReqPacket,
+                            messageType,
+                            () -> isEligibleTeamRecipient(c, room, senderPos),
+                            translationService()
+                    );
                 }
             }
-            connection.sendTCP(chatRoomMessage); // Send to sender
+            sendMessage(
+                    client,
+                    client,
+                    chatRoomReqPacket,
+                    messageType,
+                    () -> client.getActiveRoom() == room,
+                    translationService()
+            );
         } else {
-            GameManager.getInstance().getClientsInRoom(room.getRoomId()).forEach(c -> c.getConnection().sendTCP(chatRoomMessage));
+            LibreTranslateTranslationService translationService = translationService();
+            GameManager.getInstance().getClientsInRoom(room.getRoomId()).forEach(recipient ->
+                    sendMessage(
+                            recipient,
+                            client,
+                            chatRoomReqPacket,
+                            messageType,
+                            () -> recipient.getActiveRoom() == room,
+                            translationService
+                    )
+            );
         }
     }
 
-    private boolean areInSameTeam(int playerPos1, int playerPos2) {
+    private static LibreTranslateTranslationService translationService() {
+        return ChatTranslationServices.get();
+    }
+
+    private static void sendMessage(
+            FTClient recipient,
+            FTClient sender,
+            CMSGChatMessageRoom request,
+            byte messageType,
+            BooleanSupplier stillEligible,
+            LibreTranslateTranslationService translationService
+    ) {
+        String senderName = sender.getPlayer().getName();
+        int textColor = sender.getTextMode();
+        long membershipGeneration = recipient.getRoomMembershipGeneration();
+        recipient.getChatDelivery().enqueue(
+                messageForRecipient(sender, recipient, request.getMessage(), translationService),
+                message -> {
+                    FTConnection connection = recipient.getConnection();
+                    if (recipient.getRoomMembershipGeneration() != membershipGeneration
+                            || !stillEligible.getAsBoolean()
+                            || connection == null) {
+                        return;
+                    }
+                    connection.sendTCP(
+                            SMSGChatMessageRoom.builder()
+                                    .type(messageType)
+                                    .sender(senderName)
+                                    .message(message)
+                                    .textColor(textColor)
+                                    .build()
+                    );
+                }
+        );
+    }
+
+    private static boolean isEligibleTeamRecipient(FTClient recipient, Room room, short senderPosition) {
+        if (recipient.getActiveRoom() != room || !recipient.hasPlayer()) {
+            return false;
+        }
+        RoomPlayer roomPlayer = recipient.getRoomPlayer();
+        return roomPlayer != null
+                && roomPlayer.getPlayerId() == recipient.getPlayer().getId()
+                && (areInSameTeam(senderPosition, roomPlayer.getPosition())
+                || roomPlayer.getPosition() == MiscConstants.InvisibleGmSlot);
+    }
+
+    static CompletableFuture<String> messageForRecipient(
+            FTClient sender,
+            FTClient recipient,
+            String message,
+            LibreTranslateTranslationService translationService
+    ) {
+        if (recipient == sender || !recipient.isTranslateChatToEnglish()) {
+            return CompletableFuture.completedFuture(message);
+        }
+        return translationService.translateToEnglish(message);
+    }
+
+    private static boolean areInSameTeam(int playerPos1, int playerPos2) {
         boolean bothInRedTeam = (playerPos1 == 0 && playerPos2 == 2) || (playerPos1 == 2 && playerPos2 == 0);
         boolean bothInBlueTeam = (playerPos1 == 1 && playerPos2 == 3) || (playerPos1 == 3 && playerPos2 == 1);
         return bothInRedTeam || bothInBlueTeam;

--- a/chat-server/src/main/java/com/jftse/emulator/server/net/FTClient.java
+++ b/chat-server/src/main/java/com/jftse/emulator/server/net/FTClient.java
@@ -15,12 +15,14 @@ import com.jftse.server.core.constants.GameMode;
 import com.jftse.server.core.net.Client;
 import com.jftse.server.core.shared.PlayerLoadType;
 import com.jftse.server.core.shared.packets.game.SMSGReceiveData;
+import com.jftse.server.core.translation.OrderedChatDelivery;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Getter
@@ -36,10 +38,12 @@ public class FTClient extends Client<FTConnection> {
     private TutorialGame activeTutorialGame;
 
     private Room activeRoom;
+    private final AtomicLong roomMembershipGenerationCounter = new AtomicLong();
 
     private FruitManager fruitManager = new FruitManager();
 
     private volatile boolean inLobby = false;
+    private final AtomicLong lobbyMembershipGenerationCounter = new AtomicLong();
     private volatile boolean isSpectator = false;
 
     private volatile int lobbyGameModeTabFilter = GameMode.ALL;
@@ -65,6 +69,30 @@ public class FTClient extends Client<FTConnection> {
     private Pet activePet;
 
     private int textMode = 0;
+    private volatile boolean translateChatToEnglish = false;
+    private final OrderedChatDelivery chatDelivery = new OrderedChatDelivery();
+
+    public void setActiveRoom(Room activeRoom) {
+        if (this.activeRoom != activeRoom) {
+            roomMembershipGenerationCounter.incrementAndGet();
+        }
+        this.activeRoom = activeRoom;
+    }
+
+    public long getRoomMembershipGeneration() {
+        return roomMembershipGenerationCounter.get();
+    }
+
+    public void setInLobby(boolean inLobby) {
+        if (this.inLobby != inLobby) {
+            lobbyMembershipGenerationCounter.incrementAndGet();
+        }
+        this.inLobby = inLobby;
+    }
+
+    public long getLobbyMembershipGeneration() {
+        return lobbyMembershipGenerationCounter.get();
+    }
 
     public boolean updateDataRequestStep(int step) {
         boolean valid = dataRequestStep.compareAndSet(step - 1, step);
@@ -95,6 +123,7 @@ public class FTClient extends Client<FTConnection> {
         this.gameMaster = account.getGameMaster();
         this.accountStatus = account.getStatus();
         this.ap.set(account.getAp());
+        this.translateChatToEnglish = Boolean.TRUE.equals(player.getTranslateChatToEnglish());
         this.ftPlayer.set(loadPlayer(player, playerLoadType));
     }
 

--- a/chat-server/src/main/resources/application.properties
+++ b/chat-server/src/main/resources/application.properties
@@ -19,7 +19,7 @@ jftse.rabbitmq.exchange=fantasy-messenger
 jftse.rabbitmq.binding=system.motd chat.messenger.# chat.player.#
 jftse.rabbitmq.metrics.enabled=true
 
-grpc.server.port=9900
+grpc.server.port=${GRPC_SERVER_PORT:9900}
 
 grpc.client.GLOBAL.negotiation-type=plaintext
 grpc.client.auth-server.address=static://localhost:9898

--- a/chat-server/src/test/java/com/jftse/emulator/server/core/command/ChatTranslationCommandIntegrationTest.java
+++ b/chat-server/src/test/java/com/jftse/emulator/server/core/command/ChatTranslationCommandIntegrationTest.java
@@ -1,0 +1,188 @@
+package com.jftse.emulator.server.core.command;
+
+import com.jftse.emulator.server.core.client.FTPlayer;
+import com.jftse.emulator.server.core.command.commands.player.TranslateChatCommand;
+import com.jftse.emulator.server.core.life.room.Room;
+import com.jftse.emulator.server.core.manager.GameManager;
+import com.jftse.emulator.server.core.manager.ServiceManager;
+import com.jftse.emulator.server.core.packets.chat.S2CChatLobbyAnswerPacket;
+import com.jftse.emulator.server.core.packets.chat.S2CChatRoomAnswerPacket;
+import com.jftse.emulator.server.net.FTClient;
+import com.jftse.emulator.server.net.FTConnection;
+import com.jftse.entities.database.model.account.Account;
+import com.jftse.entities.database.model.player.Player;
+import com.jftse.entities.database.model.player.PlayerStatistic;
+import com.jftse.entities.database.model.pocket.Pocket;
+import com.jftse.server.core.protocol.IPacket;
+import com.jftse.server.core.service.CommandLogService;
+import com.jftse.server.core.service.PlayerService;
+import com.jftse.server.core.service.ScriptStateService;
+import com.jftse.server.core.shared.PlayerLoadType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ChatTranslationCommandIntegrationTest {
+    private Object previousGameManager;
+    private Object previousServiceManager;
+
+    private CommandManager commandManager;
+    private ServiceManager serviceManager;
+    private PlayerService playerService;
+    private FTConnection connection;
+    private FTClient client;
+    private Player player;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        GameManager gameManager = mock(GameManager.class);
+        serviceManager = mock(ServiceManager.class);
+        playerService = mock(PlayerService.class);
+
+        when(gameManager.getServiceManager()).thenReturn(serviceManager);
+        when(serviceManager.getCommandLogService()).thenReturn(mock(CommandLogService.class));
+        when(serviceManager.getPlayerService()).thenReturn(playerService);
+
+        previousGameManager = replaceStatic(GameManager.class, "instance", gameManager);
+        previousServiceManager = replaceStatic(ServiceManager.class, "instance", serviceManager);
+
+        commandManager = new CommandManager(mock(ScriptStateService.class));
+        commandManager.setRegisteredCommands(new LinkedHashMap<>());
+        commandManager.registerCommand("translate", 0, new TranslateChatCommand());
+
+        connection = mock(FTConnection.class);
+        client = mock(FTClient.class);
+        Account account = mock(Account.class);
+        FTPlayer ftPlayer = mock(FTPlayer.class);
+        player = new Player();
+
+        when(connection.getClient()).thenReturn(client);
+        when(client.getAccount()).thenReturn(account);
+        when(account.getGameMaster()).thenReturn(false);
+        when(client.hasPlayer()).thenReturn(true);
+        when(client.getPlayer()).thenReturn(ftPlayer);
+        when(ftPlayer.getPlayer()).thenReturn(player);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        replaceStatic(GameManager.class, "instance", previousGameManager);
+        replaceStatic(ServiceManager.class, "instance", previousServiceManager);
+    }
+
+    @Test
+    void dispatchesPostCommandArgumentAndPersistsPreference() {
+        commandManager.handle(connection, "-translate on");
+
+        verify(client).setTranslateChatToEnglish(true);
+        verify(playerService).save(player);
+    }
+
+    @Test
+    void normalizesCommandNameAndSurroundingWhitespace() {
+        assertTrue(commandManager.isCommand("  -TRANSLATE on  "));
+
+        commandManager.handle(connection, "  -TRANSLATE on  ");
+
+        verify(client).setTranslateChatToEnglish(true);
+        verify(playerService).save(player);
+    }
+
+    @Test
+    void persistsDisabledPreference() {
+        player.setTranslateChatToEnglish(true);
+
+        commandManager.handle(connection, "-translate off");
+
+        assertFalse(player.getTranslateChatToEnglish());
+        verify(client).setTranslateChatToEnglish(false);
+        verify(playerService).save(player);
+    }
+
+    @Test
+    void rollsBackAndReportsFailedPreferenceSave() {
+        doThrow(new RuntimeException("database unavailable")).when(playerService).save(player);
+
+        commandManager.handle(connection, "-translate on");
+
+        assertFalse(player.getTranslateChatToEnglish());
+        verify(client, never()).setTranslateChatToEnglish(true);
+        verify(connection).sendTCP(argThat((IPacket packet) ->
+                packet instanceof S2CChatLobbyAnswerPacket));
+    }
+
+    @Test
+    void invalidModeDoesNotChangeOrPersistPreference() {
+        commandManager.handle(connection, "-translate maybe");
+
+        verify(client, never()).setTranslateChatToEnglish(true);
+        verify(client, never()).setTranslateChatToEnglish(false);
+        verify(playerService, never()).save(player);
+    }
+
+    @Test
+    void roomCommandUsesRoomChatFeedback() {
+        when(client.getActiveRoom()).thenReturn(mock(Room.class));
+
+        commandManager.handle(connection, "-translate off");
+
+        verify(connection).sendTCP(argThat((IPacket packet) ->
+                packet instanceof S2CChatRoomAnswerPacket));
+    }
+
+    @Test
+    void freshClientRestoresPersistedPreference() {
+        Player persistedPlayer = new Player();
+        persistedPlayer.setId(1L);
+        persistedPlayer.setPlayerType((byte) 0);
+        Field preference = assertDoesNotThrow(
+                () -> Player.class.getDeclaredField("translateChatToEnglish"));
+        preference.setAccessible(true);
+        assertDoesNotThrow(() -> preference.set(persistedPlayer, true));
+
+        Account account = new Account();
+        account.setId(1L);
+        account.setAp(0);
+        account.setGameMaster(false);
+        account.setStatus(0);
+        persistedPlayer.setAccount(account);
+        Pocket pocket = new Pocket();
+        pocket.setId(1L);
+        persistedPlayer.setPocket(pocket);
+        PlayerStatistic statistic = new PlayerStatistic();
+        statistic.setId(1L);
+        persistedPlayer.setPlayerStatistic(statistic);
+
+        FTClient freshClient = new FTClient();
+        freshClient.loadPlayer(account, persistedPlayer, PlayerLoadType.BASIC);
+
+        assertTrue(freshClient.isTranslateChatToEnglish());
+    }
+
+    @Test
+    void newPlayerDefaultsToTranslationDisabled() {
+        FTClient freshClient = new FTClient();
+        assertFalse(freshClient.isTranslateChatToEnglish());
+    }
+
+    private static Object replaceStatic(Class<?> type, String fieldName, Object value) throws Exception {
+        Field field = type.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Object previous = field.get(null);
+        field.set(null, value);
+        return previous;
+    }
+}

--- a/chat-server/src/test/java/com/jftse/emulator/server/core/handler/chat/ChatTranslationCharacterizationTest.java
+++ b/chat-server/src/test/java/com/jftse/emulator/server/core/handler/chat/ChatTranslationCharacterizationTest.java
@@ -1,0 +1,148 @@
+package com.jftse.emulator.server.core.handler.chat;
+
+import com.jftse.emulator.server.net.FTClient;
+import com.jftse.server.core.translation.LibreTranslateTranslationService;
+import com.jftse.server.core.shared.packets.chat.SMSGChatMessageLobby;
+import com.jftse.server.core.shared.packets.chat.SMSGChatMessageRoom;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ChatTranslationCharacterizationTest {
+    private static final String THAI_MESSAGE = "มีใครอยากเล่นคู่ไหม";
+    private static final String ENGLISH_MESSAGE = "Does anyone want to play doubles?";
+
+    private HttpServer server;
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void preservesLobbyAndRoomPacketMetadata() {
+        SMSGChatMessageLobby lobby = SMSGChatMessageLobby.builder()
+                .unk((char) 7)
+                .sender("Somchai")
+                .message("มีใครอยากเล่นคู่ไหม")
+                .textColor(3)
+                .build();
+        SMSGChatMessageRoom room = SMSGChatMessageRoom.builder()
+                .type((byte) 1)
+                .sender("Somchai")
+                .message("มีใครอยากเล่นคู่ไหม")
+                .textColor(3)
+                .build();
+
+        assertEquals((char) 7, lobby.getUnk());
+        assertEquals("Somchai", lobby.getSender());
+        assertEquals("มีใครอยากเล่นคู่ไหม", lobby.getMessage());
+        assertEquals(3, lobby.getTextColor());
+        assertEquals((byte) 1, room.getType());
+        assertEquals("Somchai", room.getSender());
+        assertEquals("มีใครอยากเล่นคู่ไหม", room.getMessage());
+        assertEquals(3, room.getTextColor());
+    }
+
+    @Test
+    void preservesRoomTeamVisibilityRules() throws Exception {
+        ChatMessageRoomPacketHandler handler = new ChatMessageRoomPacketHandler();
+        Method areInSameTeam = ChatMessageRoomPacketHandler.class
+                .getDeclaredMethod("areInSameTeam", int.class, int.class);
+        areInSameTeam.setAccessible(true);
+
+        assertTrue((boolean) areInSameTeam.invoke(handler, 0, 2));
+        assertTrue((boolean) areInSameTeam.invoke(handler, 1, 3));
+        assertFalse((boolean) areInSameTeam.invoke(handler, 0, 1));
+        assertFalse((boolean) areInSameTeam.invoke(handler, 2, 3));
+    }
+
+    @Test
+    void routesOriginalToSenderAndThaiRecipientsAndTranslationToEnglishRecipients() throws Exception {
+        AtomicInteger providerCalls = new AtomicInteger();
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/translate", exchange -> {
+            providerCalls.incrementAndGet();
+            byte[] response = ("{\"translatedText\":\"" + ENGLISH_MESSAGE + "\"}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+
+        LibreTranslateTranslationService service = new LibreTranslateTranslationService(
+                HttpClient.newHttpClient(),
+                URI.create("http://127.0.0.1:" + server.getAddress().getPort() + "/translate"),
+                Duration.ofMillis(500),
+                true
+        );
+        FTClient sender = new FTClient();
+        FTClient thaiRecipient = new FTClient();
+        FTClient englishRecipientOne = new FTClient();
+        FTClient englishRecipientTwo = new FTClient();
+        Method setTranslation = FTClient.class.getMethod("setTranslateChatToEnglish", boolean.class);
+        setTranslation.invoke(sender, true);
+        setTranslation.invoke(englishRecipientOne, true);
+        setTranslation.invoke(englishRecipientTwo, true);
+
+        CompletableFuture<String> senderMessage = resolveMessage(
+                ChatMessageLobbyPacketHandler.class, sender, sender, service
+        );
+        CompletableFuture<String> thaiMessage = resolveMessage(
+                ChatMessageLobbyPacketHandler.class, sender, thaiRecipient, service
+        );
+        CompletableFuture<String> englishLobbyMessageOne = resolveMessage(
+                ChatMessageLobbyPacketHandler.class, sender, englishRecipientOne, service
+        );
+        CompletableFuture<String> englishLobbyMessageTwo = resolveMessage(
+                ChatMessageLobbyPacketHandler.class, sender, englishRecipientTwo, service
+        );
+        CompletableFuture<String> englishRoomMessage = resolveMessage(
+                ChatMessageRoomPacketHandler.class, sender, englishRecipientOne, service
+        );
+
+        assertEquals(THAI_MESSAGE, senderMessage.get(1, TimeUnit.SECONDS));
+        assertEquals(THAI_MESSAGE, thaiMessage.get(1, TimeUnit.SECONDS));
+        assertEquals(ENGLISH_MESSAGE, englishLobbyMessageOne.get(1, TimeUnit.SECONDS));
+        assertEquals(ENGLISH_MESSAGE, englishLobbyMessageTwo.get(1, TimeUnit.SECONDS));
+        assertEquals(ENGLISH_MESSAGE, englishRoomMessage.get(1, TimeUnit.SECONDS));
+        assertEquals(1, providerCalls.get());
+    }
+
+    @SuppressWarnings("unchecked")
+    private CompletableFuture<String> resolveMessage(
+            Class<?> handlerType,
+            FTClient sender,
+            FTClient recipient,
+            LibreTranslateTranslationService service
+    ) throws Exception {
+        Method resolver = handlerType.getDeclaredMethod(
+                "messageForRecipient",
+                FTClient.class,
+                FTClient.class,
+                String.class,
+                LibreTranslateTranslationService.class
+        );
+        resolver.setAccessible(true);
+        return (CompletableFuture<String>) resolver.invoke(null, sender, recipient, THAI_MESSAGE, service);
+    }
+}

--- a/chat-server/src/test/java/com/jftse/emulator/server/core/handler/chat/ChatTranslationHandlerIntegrationTest.java
+++ b/chat-server/src/test/java/com/jftse/emulator/server/core/handler/chat/ChatTranslationHandlerIntegrationTest.java
@@ -1,0 +1,329 @@
+package com.jftse.emulator.server.core.handler.chat;
+
+import com.jftse.emulator.server.core.client.FTPlayer;
+import com.jftse.emulator.server.core.command.CommandManager;
+import com.jftse.emulator.server.core.constants.RoomStatus;
+import com.jftse.emulator.server.core.life.room.Room;
+import com.jftse.emulator.server.core.life.room.RoomPlayer;
+import com.jftse.emulator.server.core.manager.GameManager;
+import com.jftse.emulator.server.net.FTClient;
+import com.jftse.emulator.server.net.FTConnection;
+import com.jftse.server.core.protocol.IPacket;
+import com.jftse.server.core.shared.packets.chat.CMSGChatMessageLobby;
+import com.jftse.server.core.shared.packets.chat.CMSGChatMessageRoom;
+import com.jftse.server.core.shared.packets.chat.SMSGChatMessageLobby;
+import com.jftse.server.core.shared.packets.chat.SMSGChatMessageRoom;
+import com.jftse.server.core.translation.ChatTranslationServices;
+import com.jftse.server.core.translation.LibreTranslateTranslationService;
+import com.jftse.server.core.translation.OrderedChatDelivery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ChatTranslationHandlerIntegrationTest {
+    private static final String THAI_FIRST = "ก ข้อความแรก";
+    private static final String THAI_SECOND = "ก ข้อความที่สอง";
+
+    private Object previousGameManager;
+    private Object previousCommandManager;
+    private LibreTranslateTranslationService previousTranslationService;
+
+    private GameManager gameManager;
+    private CommandManager commandManager;
+    private ControlledProvider provider;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        gameManager = mock(GameManager.class);
+        commandManager = mock(CommandManager.class);
+        when(commandManager.isCommand(anyString())).thenReturn(false);
+
+        previousGameManager = replaceStatic(GameManager.class, "instance", gameManager);
+        previousCommandManager = replaceStatic(CommandManager.class, "instance", commandManager);
+
+        previousTranslationService = ChatTranslationServices.get();
+        provider = new ControlledProvider();
+        ChatTranslationServices.configure(provider.service());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        provider.completeAll("{\"translatedText\":\"cleanup\"}");
+        ChatTranslationServices.configure(previousTranslationService);
+        replaceStatic(GameManager.class, "instance", previousGameManager);
+        replaceStatic(CommandManager.class, "instance", previousCommandManager);
+    }
+
+    @Test
+    void preservesPerRecipientOrderWhenTranslationsCompleteInReverse() {
+        Room room = runningRoom(7);
+        ClientFixture sender = client("Sender", 1L, (short) 0, room, false, false);
+        ClientFixture recipient = client("English", 2L, (short) 2, room, false, true);
+        when(gameManager.getClientsInRoom((short) 7)).thenReturn(List.of(recipient.client));
+
+        ChatMessageRoomPacketHandler handler = new ChatMessageRoomPacketHandler();
+        handler.handle(sender.connection, roomRequest((byte) 0, THAI_FIRST));
+        handler.handle(sender.connection, roomRequest((byte) 0, THAI_SECOND));
+
+        assertEquals(2, provider.pendingCount());
+        provider.complete(1, "{\"translatedText\":\"second\"}");
+        provider.complete(0, "{\"translatedText\":\"first\"}");
+
+        ArgumentCaptor<IPacket> packets = ArgumentCaptor.forClass(IPacket.class);
+        verify(recipient.connection, times(2)).sendTCP(packets.capture());
+        assertEquals(List.of("first", "second"), packets.getAllValues().stream()
+                .map(ChatTranslationHandlerIntegrationTest::roomMessage)
+                .toList());
+    }
+
+    @Test
+    void dropsDelayedLobbyMessageAfterRecipientLeavesLobby() {
+        AtomicBoolean recipientInLobby = new AtomicBoolean(true);
+        ClientFixture sender = client("Sender", 1L, (short) 0, null, true, false);
+        ClientFixture recipient = client("English", 2L, (short) 2, null, true, true);
+        when(recipient.client.isInLobby()).thenAnswer(invocation -> recipientInLobby.get());
+        when(gameManager.getClients()).thenReturn(
+                new ConcurrentLinkedDeque<>(List.of(recipient.client)));
+
+        new ChatMessageLobbyPacketHandler().handle(
+                sender.connection,
+                CMSGChatMessageLobby.builder().unk((char) 1).message(THAI_FIRST).build()
+        );
+        recipientInLobby.set(false);
+        provider.complete(0, "{\"translatedText\":\"first\"}");
+
+        verify(recipient.connection, never()).sendTCP(any(IPacket.class));
+    }
+
+    @Test
+    void dropsDelayedLobbyMessageAfterRecipientLeavesAndRejoins() {
+        ClientFixture sender = client("Sender", 1L, (short) 0, null, true, false);
+        ClientFixture recipient = client("English", 2L, (short) 2, null, true, true);
+        when(recipient.client.getLobbyMembershipGeneration()).thenReturn(1L, 3L);
+        when(gameManager.getClients()).thenReturn(
+                new ConcurrentLinkedDeque<>(List.of(recipient.client)));
+
+        new ChatMessageLobbyPacketHandler().handle(
+                sender.connection,
+                CMSGChatMessageLobby.builder().unk((char) 1).message(THAI_FIRST).build()
+        );
+        provider.complete(0, "{\"translatedText\":\"first\"}");
+
+        verify(recipient.connection, never()).sendTCP(any(IPacket.class));
+    }
+
+    @Test
+    void dropsDelayedRoomMessageAfterRecipientLeavesAndRejoins() {
+        Room room = runningRoom(8);
+        ClientFixture sender = client("Sender", 1L, (short) 0, room, false, false);
+        ClientFixture recipient = client("English", 2L, (short) 2, room, false, true);
+        when(recipient.client.getRoomMembershipGeneration()).thenReturn(1L, 3L);
+        when(gameManager.getClientsInRoom((short) 8)).thenReturn(List.of(recipient.client));
+
+        new ChatMessageRoomPacketHandler().handle(
+                sender.connection,
+                roomRequest((byte) 0, THAI_FIRST)
+        );
+        provider.complete(0, "{\"translatedText\":\"first\"}");
+
+        verify(recipient.connection, never()).sendTCP(any(IPacket.class));
+    }
+
+    @Test
+    void runningTeamChatUsesActualHandlerAndPreservesVisibility() {
+        Room room = runningRoom(9);
+        ClientFixture sender = client("Sender", 1L, (short) 0, room, false, false);
+        ClientFixture teammate = client("Teammate", 2L, (short) 2, room, false, true);
+        ClientFixture opponent = client("Opponent", 3L, (short) 1, room, false, true);
+        when(gameManager.getClientsInRoom((short) 9))
+                .thenReturn(List.of(sender.client, teammate.client, opponent.client));
+
+        new ChatMessageRoomPacketHandler().handle(
+                sender.connection,
+                roomRequest((byte) 1, THAI_FIRST)
+        );
+        provider.complete(0, "{\"translatedText\":\"team message\"}");
+
+        assertEquals(RoomStatus.Running, room.getStatus());
+        verify(sender.connection).sendTCP(any(IPacket.class));
+        ArgumentCaptor<IPacket> packet = ArgumentCaptor.forClass(IPacket.class);
+        verify(teammate.connection).sendTCP(packet.capture());
+        assertEquals("team message", roomMessage(packet.getValue()));
+        verify(opponent.connection, never()).sendTCP(any(IPacket.class));
+    }
+
+    @Test
+    void lobbyHandlerSendsOriginalAndTranslatedPackets() {
+        ClientFixture sender = client("Sender", 1L, (short) 0, null, true, false);
+        ClientFixture thaiRecipient = client("Thai", 2L, (short) 2, null, true, false);
+        ClientFixture englishRecipient = client("English", 3L, (short) 1, null, true, true);
+        when(gameManager.getClients()).thenReturn(new ConcurrentLinkedDeque<>(
+                List.of(sender.client, thaiRecipient.client, englishRecipient.client)));
+
+        new ChatMessageLobbyPacketHandler().handle(
+                sender.connection,
+                CMSGChatMessageLobby.builder().unk((char) 1).message(THAI_FIRST).build()
+        );
+        provider.complete(0, "{\"translatedText\":\"translated\"}");
+
+        ArgumentCaptor<IPacket> senderPacket = ArgumentCaptor.forClass(IPacket.class);
+        verify(sender.connection).sendTCP(senderPacket.capture());
+        assertEquals(THAI_FIRST, lobbyMessage(senderPacket.getValue()));
+
+        ArgumentCaptor<IPacket> thaiPacket = ArgumentCaptor.forClass(IPacket.class);
+        verify(thaiRecipient.connection).sendTCP(thaiPacket.capture());
+        assertEquals(THAI_FIRST, lobbyMessage(thaiPacket.getValue()));
+
+        ArgumentCaptor<IPacket> englishPacket = ArgumentCaptor.forClass(IPacket.class);
+        verify(englishRecipient.connection).sendTCP(englishPacket.capture());
+        assertEquals("translated", lobbyMessage(englishPacket.getValue()));
+    }
+
+    @Test
+    void commandShortCircuitsProviderAndBroadcast() {
+        ClientFixture sender = client("Sender", 1L, (short) 0, null, true, false);
+        ClientFixture other = client("Other", 2L, (short) 2, null, true, true);
+        when(gameManager.getClients()).thenReturn(
+                new ConcurrentLinkedDeque<>(List.of(sender.client, other.client)));
+        when(commandManager.isCommand("-translate on")).thenReturn(true);
+
+        new ChatMessageLobbyPacketHandler().handle(
+                sender.connection,
+                CMSGChatMessageLobby.builder().unk((char) 1).message("-translate on").build()
+        );
+
+        verify(commandManager).handle(sender.connection, "-translate on");
+        verify(sender.connection).sendTCP(any(IPacket.class));
+        verify(other.connection, never()).sendTCP(any(IPacket.class));
+        assertEquals(0, provider.requestCount);
+    }
+
+    private static Room runningRoom(int roomId) {
+        Room room = new Room();
+        room.setRoomId((short) roomId);
+        room.setStatus(RoomStatus.Running);
+        return room;
+    }
+
+    private static CMSGChatMessageRoom roomRequest(byte type, String message) {
+        return CMSGChatMessageRoom.builder().type(type).message(message).build();
+    }
+
+    private static ClientFixture client(
+            String name,
+            long id,
+            short position,
+            Room room,
+            boolean inLobby,
+            boolean translate
+    ) {
+        FTClient client = mock(FTClient.class);
+        FTConnection connection = mock(FTConnection.class);
+        FTPlayer player = mock(FTPlayer.class);
+        RoomPlayer roomPlayer = mock(RoomPlayer.class);
+
+        when(connection.getClient()).thenReturn(client);
+        when(client.getConnection()).thenReturn(connection);
+        when(client.hasPlayer()).thenReturn(true);
+        when(client.getPlayer()).thenReturn(player);
+        when(client.getRoomPlayer()).thenReturn(roomPlayer);
+        when(client.getActiveRoom()).thenReturn(room);
+        when(client.isInLobby()).thenReturn(inLobby);
+        when(client.isTranslateChatToEnglish()).thenReturn(translate);
+        when(client.getChatDelivery()).thenReturn(new OrderedChatDelivery());
+        when(player.getName()).thenReturn(name);
+        when(player.getId()).thenReturn(id);
+        when(roomPlayer.getPlayerId()).thenReturn(id);
+        when(roomPlayer.getPosition()).thenReturn(position);
+        return new ClientFixture(client, connection);
+    }
+
+    private static String lobbyMessage(IPacket packet) {
+        return ((SMSGChatMessageLobby) packet).getMessage();
+    }
+
+    private static String roomMessage(IPacket packet) {
+        return ((SMSGChatMessageRoom) packet).getMessage();
+    }
+
+    private static Object replaceStatic(Class<?> type, String fieldName, Object value) throws Exception {
+        Field field = type.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Object previous = field.get(null);
+        field.set(null, value);
+        return previous;
+    }
+
+    private record ClientFixture(FTClient client, FTConnection connection) {
+    }
+
+    private static final class ControlledProvider {
+        private final HttpClient client = mock(HttpClient.class);
+        private final List<CompletableFuture<HttpResponse<String>>> pending = new ArrayList<>();
+        private int requestCount;
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        private ControlledProvider() {
+            when(client.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                    .thenAnswer(invocation -> {
+                        requestCount++;
+                        CompletableFuture<HttpResponse<String>> response = new CompletableFuture<>();
+                        pending.add(response);
+                        return response;
+                    });
+        }
+
+        private LibreTranslateTranslationService service() {
+            return new LibreTranslateTranslationService(
+                    client,
+                    URI.create("http://provider.invalid/translate"),
+                    Duration.ofSeconds(5),
+                    true
+            );
+        }
+
+        private int pendingCount() {
+            return pending.size();
+        }
+
+        private void complete(int index, String body) {
+            CompletableFuture<HttpResponse<String>> future = pending.get(index);
+            HttpResponse<String> response = mock(HttpResponse.class);
+            when(response.statusCode()).thenReturn(200);
+            when(response.body()).thenReturn(body);
+            future.complete(response);
+        }
+
+        private void completeAll(String body) {
+            for (int index = 0; index < pending.size(); index++) {
+                if (!pending.get(index).isDone()) {
+                    complete(index, body);
+                }
+            }
+        }
+    }
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,19 +1,20 @@
-version: '3.8'
-
 services:
   rabbitmq:
     build:
       context: ./rabbitmq
       dockerfile: Dockerfile
-    container_name: rabbitmq-server
-    hostname: rabbitmq-server
     volumes:
       - ./rabbitmq/definitions.json:/etc/rabbitmq/definitions.json
       - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     restart: always
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
     ports:
-      - "5672:5672"
-      - "15672:15672"
+      - "${RABBITMQ_PORT:-5672}:5672"
+      - "${RABBITMQ_MANAGEMENT_PORT:-15672}:15672"
     networks:
       - rabbitmq-network
 
@@ -21,40 +22,157 @@ services:
     build:
       context: ./mysql-db
       dockerfile: Dockerfile
-    container_name: mysql-db-server
-    hostname: mysql-db-server
     command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: 123456
     restart: always
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-p123456"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
     ports:
-      - "3306:3306"
+      - "${MYSQL_PORT:-3306}:3306"
     networks:
       - db-network
 
-  emulator:
-    build:
-      context: ..
-      dockerfile: docker/emulator/Dockerfile
-    container_name: emulator-server
-    hostname: emulator-server
+  database-import:
+    image: jftse-emulator:local
     depends_on:
-      - "mysql-db"
-      - "rabbitmq"
-    ports:
-      - "5894:5894"
-      - "5895:5895"
-      - "5896:5896"
-      - "5897:5897"
-      - "3724:3724"
+      mysql-db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: "jdbc:mysql://mysql-db:3306/fantasytennis?autoReconnect=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Europe/Berlin"
+      SPRING_RABBITMQ_HOST: "rabbitmq"
+    working_dir: /opt/jftse/auth-server/target/dist
+    command:
+      - java
+      - -Djava.net.preferIPv4Stack=true
+      - -Dconf.path=/opt/jftse/auth-server/target/dist
+      - -jar
+      - /opt/jftse/auth-server/target/auth-server.jar
+      - -import-only
+    restart: "no"
     networks:
       - db-network
       - rabbitmq-network
 
+  database-fixtures:
+    image: mysql@sha256:6e0014cdd88092545557dee5e9eb7e1a3c84c9a14ad2418d5f2231e930967a38
+    depends_on:
+      database-import:
+        condition: service_completed_successfully
+    environment:
+      MYSQL_PWD: "123456"
+    volumes:
+      - ../scripts/sql:/fixtures:ro
+    entrypoint:
+      - /bin/bash
+      - -ec
+    command:
+      - |
+        until mysql -hmysql-db -uroot -N -e \
+          "SELECT COUNT(*) FROM fantasytennis.S_Relationship_Roles" >/dev/null 2>&1; do
+          sleep 1
+        done
+        required_data="$$(mysql -hmysql-db -uroot -N fantasytennis -e \
+          "SELECT
+             (SELECT COUNT(*) FROM Product) > 0
+             AND (SELECT COUNT(*) FROM Guardian) > 0
+             AND (SELECT COUNT(*) FROM Skill) > 0
+             AND (SELECT COUNT(*) FROM LevelExp) > 0")"
+        if [ "$${required_data}" != "1" ]; then
+          echo "Required auth-server import data is incomplete" >&2
+          exit 1
+        fi
+        mysql -hmysql-db -uroot fantasytennis -e \
+          "CREATE TABLE IF NOT EXISTS DeploymentFixtureVersion (
+            version VARCHAR(64) PRIMARY KEY,
+            installed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+          ) ENGINE=InnoDB"
+        if [ "$$(mysql -hmysql-db -uroot -N fantasytennis -e \
+          "SELECT COUNT(*) FROM DeploymentFixtureVersion
+           WHERE version = 'scripts-sql-v1'")" -eq 0 ]; then
+          {
+            echo "SET SESSION FOREIGN_KEY_CHECKS=0;"
+            echo "START TRANSACTION;"
+            for fixture in /fixtures/*.sql; do
+              echo "Loading canonical fixture: $${fixture}" >&2
+              cat "$${fixture}"
+            done
+            echo "INSERT INTO DeploymentFixtureVersion(version) VALUES ('scripts-sql-v1');"
+            echo "COMMIT;"
+          } | mysql -hmysql-db -uroot fantasytennis
+        fi
+    restart: "no"
+    networks:
+      - db-network
+
+  libretranslate:
+    image: jftse-libretranslate:1.9.6-models-1.9
+    build:
+      context: ./libretranslate
+      dockerfile: Dockerfile
+    environment:
+      LT_LOAD_ONLY: en,th
+      LT_UPDATE_MODELS: "false"
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:${LIBRETRANSLATE_PORT:-5000}:5000"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import json, urllib.request; q='มีใครอยากเล่นคู่ไหม'; body=json.dumps({'q':q,'source':'th','target':'en','format':'text'}).encode(); request=urllib.request.Request('http://127.0.0.1:5000/translate', data=body, headers={'Content-Type':'application/json'}); translated=json.load(urllib.request.urlopen(request, timeout=5))['translatedText']; assert translated and translated != q"
+      interval: 5s
+      timeout: 3s
+      retries: 60
+      start_period: 30s
+    networks:
+      - translation-network
+
+  emulator:
+    image: jftse-emulator:local
+    build:
+      context: ..
+      dockerfile: docker/emulator/Dockerfile
+    depends_on:
+      mysql-db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      database-import:
+        condition: service_completed_successfully
+      database-fixtures:
+        condition: service_completed_successfully
+      libretranslate:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: "jdbc:mysql://mysql-db:3306/fantasytennis?autoReconnect=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Europe/Berlin"
+      SPRING_RABBITMQ_HOST: "rabbitmq"
+      ChatTranslationEnabled: "${CHAT_TRANSLATION_ENABLED:-false}"
+      ChatTranslationEndpoint: "http://libretranslate:5000/translate"
+      ChatTranslationTimeoutMs: "${CHAT_TRANSLATION_TIMEOUT_MS:-450}"
+      ChatTranslationMaxInputChars: "${CHAT_TRANSLATION_MAX_INPUT_CHARS:-256}"
+      ChatTranslationMaxTranslatedChars: "${CHAT_TRANSLATION_MAX_TRANSLATED_CHARS:-1024}"
+      ChatTranslationMaxConcurrentRequests: "${CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS:-8}"
+    ports:
+      - "${AUTH_PORT:-5894}:5894"
+      - "${GAME_PORT:-5895}:5895"
+      - "${RELAY_PORT:-5896}:5896"
+      - "${CHAT_PORT:-5897}:5897"
+    networks:
+      - db-network
+      - rabbitmq-network
+      - translation-network
+
 networks:
   rabbitmq-network:
     driver: bridge
-    name: rabbitmq-network
   db-network:
     driver: bridge
-    name: db-network
+  translation-network:
+    driver: bridge

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -158,7 +158,7 @@ services:
       ChatTranslationTimeoutMs: "${CHAT_TRANSLATION_TIMEOUT_MS:-450}"
       ChatTranslationMaxInputChars: "${CHAT_TRANSLATION_MAX_INPUT_CHARS:-256}"
       ChatTranslationMaxTranslatedChars: "${CHAT_TRANSLATION_MAX_TRANSLATED_CHARS:-1024}"
-      ChatTranslationMaxConcurrentRequests: "${CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS:-8}"
+      ChatTranslationMaxConcurrentRequests: "${CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS:-2}"
     ports:
       - "${AUTH_PORT:-5894}:5894"
       - "${GAME_PORT:-5895}:5895"

--- a/docker/emulator/Dockerfile
+++ b/docker/emulator/Dockerfile
@@ -1,12 +1,7 @@
-FROM debian:12-slim
-
-ENV JAVA_HOME=/opt/java/jdk-21
-ENV MAVEN_HOME=/opt/maven/apache-maven-3.9.4
-ENV PATH=$PATH:${JAVA_HOME}/bin:${MAVEN_HOME}/bin
+FROM maven@sha256:2b4496088e7b80ae10a8c9f74e574ea21380325a006ec684532ad6bad5bc7273
 
 WORKDIR /opt/jftse
 
-COPY docker/emulator/build.sh build.sh
 COPY commons commons
 COPY commons-proto commons-proto
 COPY entities entities
@@ -16,24 +11,14 @@ COPY game-server game-server
 COPY chat-server chat-server
 COPY relay-server relay-server
 COPY ac-server ac-server
-COPY b2b-webservice b2b-webservice
+COPY packet-generator packet-generator
 COPY pom.xml pom.xml
 
-RUN apt-get update && apt-get install -y vim wget curl tar procps openssl supervisor
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends supervisor=4.2.5-1ubuntu0.1 \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY docker/emulator/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-
-RUN chmod +x build.sh
-RUN ./build.sh
-
-RUN sed -i "s/jdbc:mysql:\/\/localhost:3306/jdbc:mysql:\/\/mysql-db-server:3306/g" auth-server/src/main/resources/application.properties
-RUN sed -i "s/jdbc:mysql:\/\/localhost:3306/jdbc:mysql:\/\/mysql-db-server:3306/g" game-server/src/main/resources/application.properties
-RUN sed -i "s/jdbc:mysql:\/\/localhost:3306/jdbc:mysql:\/\/mysql-db-server:3306/g" chat-server/src/main/resources/application.properties
-RUN sed -i "s/jdbc:mysql:\/\/localhost:3306/jdbc:mysql:\/\/mysql-db-server:3306/g" relay-server/src/main/resources/application.properties
-RUN sed -i "s/jdbc:mysql:\/\/localhost:3306/jdbc:mysql:\/\/mysql-db-server:3306/g" ac-server/src/main/resources/application.properties
-
-RUN sed -i "s/spring.rabbitmq.host=localhost/spring.rabbitmq.host=rabbitmq-server/g" game-server/src/main/resources/application.properties
-RUN sed -i "s/spring.rabbitmq.host=localhost/spring.rabbitmq.host=rabbitmq-server/g" chat-server/src/main/resources/application.properties
 
 RUN mvn clean install
 

--- a/docker/emulator/supervisord.conf
+++ b/docker/emulator/supervisord.conf
@@ -1,26 +1,48 @@
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
 [supervisord]
 nodaemon=true
 
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
 [program:auth-server]
-command=java -Djava.net.preferIPv4Stack=true -jar /opt/jftse/auth-server/target/auth-server-1.0.0-SNAPSHOT.jar
+command=java -Djava.net.preferIPv4Stack=true -Dconf.path=/opt/jftse/auth-server/target/dist -jar /opt/jftse/auth-server/target/auth-server.jar
 autostart=true
 autorestart=true
 directory=/opt/jftse/auth-server/target
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 
 [program:game-server]
-command=java -Djava.net.preferIPv4Stack=true -jar /opt/jftse/game-server/target/game-server-1.0.0-SNAPSHOT.jar
+command=java -Djava.net.preferIPv4Stack=true -Dconf.path=/opt/jftse/game-server/target/dist -jar /opt/jftse/game-server/target/game-server.jar
 autostart=true
 autorestart=true
 directory=/opt/jftse/game-server/target
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 
 [program:chat-server]
-command=java -Djava.net.preferIPv4Stack=true -jar /opt/jftse/chat-server/target/chat-server-1.0.0-SNAPSHOT.jar
+command=java -Djava.net.preferIPv4Stack=true -Dconf.path=/opt/jftse/chat-server/target/dist -jar /opt/jftse/chat-server/target/chat-server.jar
 autostart=true
 autorestart=true
 directory=/opt/jftse/chat-server/target
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 
 [program:relay-server]
-command=java -Djava.net.preferIPv4Stack=true -jar /opt/jftse/relay-server/target/relay-server-1.0.0-SNAPSHOT.jar
+command=java -Djava.net.preferIPv4Stack=true -Dconf.path=/opt/jftse/relay-server/target/dist -jar /opt/jftse/relay-server/target/relay-server.jar
 autostart=true
 autorestart=true
 directory=/opt/jftse/relay-server/target
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0

--- a/docker/libretranslate/Dockerfile
+++ b/docker/libretranslate/Dockerfile
@@ -1,0 +1,27 @@
+FROM libretranslate/libretranslate@sha256:1de2d7056bb8ad607a412f4563d9abe324ff632b43b5be9428bcc8e213aebb32
+
+ADD --chown=libretranslate:libretranslate --chmod=0644 \
+    --checksum=sha256:b6642c07389b156f568aa08c64140243bc1b1926f82df2559a2eae08316f84ce \
+    https://data.argosopentech.com/argospm/v1/translate-th_en-1_9.argosmodel \
+    /tmp/translate-th_en-1_9.argosmodel
+ADD --chown=libretranslate:libretranslate --chmod=0644 \
+    --checksum=sha256:b0fd94eceb04b967b91c2c7d8d1f7b5493c25362e43027a52649242385d0b2a3 \
+    https://data.argosopentech.com/argospm/v1/translate-en_th-1_9.argosmodel \
+    /tmp/translate-en_th-1_9.argosmodel
+ADD --chown=libretranslate:libretranslate --chmod=0644 \
+    --checksum=sha256:6fa9f3a3b201687bd43e329b2b0736789efc97b37883b5b759b31988dca9f353 \
+    https://github.com/LibreTranslate/MiniSBD/releases/download/v0.0.1/en.onnx \
+    /tmp/en.onnx
+ADD --chown=libretranslate:libretranslate --chmod=0644 \
+    --checksum=sha256:62b94ddf5af61ddde4e99dbb4087be71135e26b897e898e5bcb8679842691450 \
+    https://github.com/LibreTranslate/MiniSBD/releases/download/v0.0.1/th.onnx \
+    /tmp/th.onnx
+
+RUN /app/venv/bin/python -c \
+      "from argostranslate.package import install_from_path; \
+       install_from_path('/tmp/translate-th_en-1_9.argosmodel'); \
+       install_from_path('/tmp/translate-en_th-1_9.argosmodel')" \
+    && mkdir -p /home/libretranslate/.local/share/argos-translate/minisbd \
+    && mv /tmp/en.onnx /tmp/th.onnx \
+      /home/libretranslate/.local/share/argos-translate/minisbd/ \
+    && rm /tmp/*.argosmodel

--- a/docker/mysql-db/Dockerfile
+++ b/docker/mysql-db/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.0.23
+FROM mysql@sha256:6e0014cdd88092545557dee5e9eb7e1a3c84c9a14ad2418d5f2231e930967a38
 
 COPY sql/create/create_fantasytennis.sql /docker-entrypoint-initdb.d/1.sql
 COPY sql/insert/account.sql /docker-entrypoint-initdb.d/2.sql

--- a/docker/rabbitmq/Dockerfile
+++ b/docker/rabbitmq/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.12-management
+FROM rabbitmq@sha256:c601bbed8c3138c74d13439d1db867c106ec76029c3c9e458c11e18c3de25b2e
 
 COPY definitions.json /etc/rabbitmq/
 COPY rabbitmq.conf /etc/rabbitmq/

--- a/entities/src/main/java/com/jftse/entities/database/model/player/Player.java
+++ b/entities/src/main/java/com/jftse/entities/database/model/player/Player.java
@@ -83,5 +83,8 @@ public class Player extends AbstractBaseModel {
     private Byte statusPoints = 0;
 
     @Column(columnDefinition = "bit(1) DEFAULT 0")
+    private Boolean translateChatToEnglish = false;
+
+    @Column(columnDefinition = "bit(1) DEFAULT 0")
     private Boolean online = false;
 }

--- a/game-server/server.conf
+++ b/game-server/server.conf
@@ -69,4 +69,4 @@ ChatTranslationEndpoint=http://libretranslate:5000/translate
 ChatTranslationTimeoutMs=450
 ChatTranslationMaxInputChars=256
 ChatTranslationMaxTranslatedChars=1024
-ChatTranslationMaxConcurrentRequests=8
+ChatTranslationMaxConcurrentRequests=2

--- a/game-server/server.conf
+++ b/game-server/server.conf
@@ -61,3 +61,12 @@ BallBaseDamage=10
 # Ball minimum damage
 # Minimum damage a ball can deal after all calculations
 BallMinDamage=20
+
+#
+# Translate Thai player chat for players who use "-translate on"
+ChatTranslationEnabled=false
+ChatTranslationEndpoint=http://libretranslate:5000/translate
+ChatTranslationTimeoutMs=450
+ChatTranslationMaxInputChars=256
+ChatTranslationMaxTranslatedChars=1024
+ChatTranslationMaxConcurrentRequests=8

--- a/game-server/src/main/java/com/jftse/emulator/GameServerStart.java
+++ b/game-server/src/main/java/com/jftse/emulator/GameServerStart.java
@@ -7,6 +7,8 @@ import com.jftse.server.core.StartupBanner;
 import com.jftse.server.core.YamlPropertySourceFactory;
 import com.jftse.server.core.protocol.PacketAutoRegister;
 import com.jftse.server.core.shared.ServerConfService;
+import com.jftse.server.core.translation.ChatTranslationServices;
+import com.jftse.server.core.translation.LibreTranslateTranslationService;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -30,6 +32,9 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 import javax.annotation.PreDestroy;
 import java.util.concurrent.ExecutionException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.concurrent.Future;
 
 @SpringBootApplication
@@ -82,6 +87,7 @@ public class GameServerStart implements CommandLineRunner {
                 .childOption(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(32 * 1024, 128 * 1024)); // 32 KB low, 128 KB high
 
         final int port = serverConfService.get("ServerPort", Integer.class);
+        configureChatTranslation();
         b.bind(port).addListener(cf -> {
             if (cf.isSuccess()) {
                 serverLoop.start();
@@ -91,6 +97,32 @@ public class GameServerStart implements CommandLineRunner {
                 log.error("Failed to start game-server: {}", cf.cause().getMessage(), cf.cause());
             }
         });
+    }
+
+    private void configureChatTranslation() {
+        boolean enabled = serverConfService.get("ChatTranslationEnabled", Boolean.class, false);
+        int timeoutMs = serverConfService.get("ChatTranslationTimeoutMs", Integer.class, 450);
+        int maximumInputChars = serverConfService.get("ChatTranslationMaxInputChars", Integer.class, 256);
+        int maximumTranslatedChars = serverConfService.get("ChatTranslationMaxTranslatedChars", Integer.class, 1024);
+        int maximumConcurrentRequests = serverConfService.get("ChatTranslationMaxConcurrentRequests", Integer.class, 8);
+        URI endpoint = URI.create(serverConfService.get(
+                "ChatTranslationEndpoint",
+                String.class,
+                "http://libretranslate:5000/translate"
+        ));
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(timeoutMs))
+                .build();
+        ChatTranslationServices.configure(new LibreTranslateTranslationService(
+                httpClient,
+                endpoint,
+                Duration.ofMillis(timeoutMs),
+                enabled,
+                maximumInputChars,
+                maximumTranslatedChars,
+                maximumConcurrentRequests
+        ));
+        log.info("Thai-to-English chat translation is {}", enabled ? "enabled" : "disabled");
     }
 
     @PreDestroy

--- a/game-server/src/main/java/com/jftse/emulator/GameServerStart.java
+++ b/game-server/src/main/java/com/jftse/emulator/GameServerStart.java
@@ -104,7 +104,11 @@ public class GameServerStart implements CommandLineRunner {
         int timeoutMs = serverConfService.get("ChatTranslationTimeoutMs", Integer.class, 450);
         int maximumInputChars = serverConfService.get("ChatTranslationMaxInputChars", Integer.class, 256);
         int maximumTranslatedChars = serverConfService.get("ChatTranslationMaxTranslatedChars", Integer.class, 1024);
-        int maximumConcurrentRequests = serverConfService.get("ChatTranslationMaxConcurrentRequests", Integer.class, 8);
+        int maximumConcurrentRequests = serverConfService.get(
+                "ChatTranslationMaxConcurrentRequests",
+                Integer.class,
+                LibreTranslateTranslationService.DEFAULT_MAX_CONCURRENT_REQUESTS
+        );
         URI endpoint = URI.create(serverConfService.get(
                 "ChatTranslationEndpoint",
                 String.class,

--- a/game-server/src/main/java/com/jftse/emulator/server/core/command/CommandManager.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/command/CommandManager.java
@@ -67,11 +67,18 @@ public class CommandManager {
     }
 
     public boolean isCommand(String content) {
-        if (StringUtils.isEmpty(content) || content.isEmpty())
+        if (StringUtils.isEmpty(content))
             return false;
 
-        char heading = content.charAt(0);
-        return heading == COMMAND_HEADING && registeredCommands.get(getCommandArgumentList(content).get(0).substring(1)) != null;
+        List<String> arguments = getCommandArgumentList(content.trim());
+        if (arguments.isEmpty()) {
+            return false;
+        }
+
+        String commandToken = arguments.get(0);
+        return commandToken.length() > 1
+                && commandToken.charAt(0) == COMMAND_HEADING
+                && registeredCommands.containsKey(commandToken.substring(1).toLowerCase(Locale.ROOT));
     }
 
     public void handle(FTConnection connection, String content) {
@@ -94,10 +101,10 @@ public class CommandManager {
     }
 
     private void executeCommand(FTConnection connection, String content) {
-        List<String> commandArgumentList = getCommandArgumentList(content);
+        List<String> commandArgumentList = getCommandArgumentList(content.trim());
 
         String commandName = commandArgumentList.get(0);
-        commandName = commandName.substring(1);
+        commandName = commandName.substring(1).toLowerCase(Locale.ROOT);
 
         commandArgumentList.remove(0);
 
@@ -134,12 +141,13 @@ public class CommandManager {
     public void registerCommand(String commandName, int rank, AbstractCommand command) {
         command.setRank(rank);
         command.setCommandName(commandName);
-        registeredCommands.put(commandName, command);
+        registeredCommands.put(commandName.toLowerCase(Locale.ROOT), command);
         log.info("Registered command -" + commandName);
     }
 
     private void registerCommands() {
         registerCommand("og", 0, new OpenGachaCommand());
+        registerCommand("translate", 0, new TranslateChatCommand());
         registerCommand("hard", 0, new HardModeCommand());
         registerCommand("arcade", 0, new ArcadeModeCommand());
         registerCommand("random", 0, new RandomModeCommand());

--- a/game-server/src/main/java/com/jftse/emulator/server/core/command/commands/player/TranslateChatCommand.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/command/commands/player/TranslateChatCommand.java
@@ -1,0 +1,69 @@
+package com.jftse.emulator.server.core.command.commands.player;
+
+import com.jftse.emulator.server.core.command.AbstractCommand;
+import com.jftse.emulator.server.core.manager.ServiceManager;
+import com.jftse.emulator.server.core.packets.chat.S2CChatLobbyAnswerPacket;
+import com.jftse.emulator.server.core.packets.chat.S2CChatRoomAnswerPacket;
+import com.jftse.emulator.server.net.FTClient;
+import com.jftse.emulator.server.net.FTConnection;
+import com.jftse.entities.database.model.player.Player;
+import com.jftse.server.core.translation.ChatTranslationServices;
+import lombok.extern.log4j.Log4j2;
+
+import java.util.List;
+import java.util.Locale;
+
+@Log4j2
+public class TranslateChatCommand extends AbstractCommand {
+    public TranslateChatCommand() {
+        setDescription("Translate Thai player chat to English");
+    }
+
+    @Override
+    public void execute(FTConnection connection, List<String> params) {
+        FTClient client = connection.getClient();
+        if (client == null || !client.hasPlayer()) {
+            sendStatus(connection, "Translation preference requires an active player");
+            return;
+        }
+
+        if (params.size() != 1) {
+            sendStatus(connection, "Use -translate on or -translate off");
+            return;
+        }
+
+        String mode = params.get(0).toLowerCase(Locale.ROOT);
+        if (!mode.equals("on") && !mode.equals("off")) {
+            sendStatus(connection, "Use -translate on or -translate off");
+            return;
+        }
+
+        boolean enabled = mode.equals("on");
+        Player player = client.getPlayer().getPlayer();
+        Boolean previousPreference = player.getTranslateChatToEnglish();
+        player.setTranslateChatToEnglish(enabled);
+        try {
+            ServiceManager.getInstance().getPlayerService().save(player);
+        } catch (RuntimeException exception) {
+            player.setTranslateChatToEnglish(previousPreference);
+            log.error("Failed to save chat translation preference for player {}", player.getId(), exception);
+            sendStatus(connection, "Translation preference could not be saved");
+            return;
+        }
+        client.setTranslateChatToEnglish(enabled);
+
+        String message = "Thai to English chat translation " + (enabled ? "enabled" : "disabled");
+        if (enabled && !ChatTranslationServices.get().isEnabled()) {
+            message += " (server translation is currently disabled)";
+        }
+        sendStatus(connection, message);
+    }
+
+    private void sendStatus(FTConnection connection, String message) {
+        if (connection.getClient() != null && connection.getClient().getActiveRoom() != null) {
+            connection.sendTCP(new S2CChatRoomAnswerPacket((byte) 2, "Translation", message));
+        } else {
+            connection.sendTCP(new S2CChatLobbyAnswerPacket((char) 0, "Translation", message));
+        }
+    }
+}

--- a/game-server/src/main/java/com/jftse/emulator/server/core/handler/chat/ChatMessageLobbyPacketHandler.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/handler/chat/ChatMessageLobbyPacketHandler.java
@@ -8,8 +8,11 @@ import com.jftse.server.core.handler.PacketHandler;
 import com.jftse.server.core.handler.PacketId;
 import com.jftse.server.core.shared.packets.chat.CMSGChatMessageLobby;
 import com.jftse.server.core.shared.packets.chat.SMSGChatMessageLobby;
+import com.jftse.server.core.translation.ChatTranslationServices;
+import com.jftse.server.core.translation.LibreTranslateTranslationService;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @PacketId(CMSGChatMessageLobby.PACKET_ID)
 public class ChatMessageLobbyPacketHandler implements PacketHandler<FTConnection, CMSGChatMessageLobby> {
@@ -37,6 +40,51 @@ public class ChatMessageLobbyPacketHandler implements PacketHandler<FTConnection
                 .filter(FTClient::isInLobby)
                 .toList();
 
-        clientList.forEach(c -> c.getConnection().sendTCP(chatLobbyMessage));
+        LibreTranslateTranslationService translationService = ChatTranslationServices.get();
+        clientList.forEach(recipient ->
+                sendMessage(recipient, client, chatLobbyReqPacket, translationService)
+        );
+    }
+
+    private static void sendMessage(
+            FTClient recipient,
+            FTClient sender,
+            CMSGChatMessageLobby request,
+            LibreTranslateTranslationService translationService
+    ) {
+        String senderName = sender.getPlayer().getName();
+        int textColor = sender.getTextMode();
+        long membershipGeneration = recipient.getLobbyMembershipGeneration();
+        recipient.getChatDelivery().enqueue(
+                messageForRecipient(sender, recipient, request.getMessage(), translationService),
+                message -> {
+                    FTConnection connection = recipient.getConnection();
+                    if (!recipient.isInLobby()
+                            || recipient.getLobbyMembershipGeneration() != membershipGeneration
+                            || connection == null) {
+                        return;
+                    }
+                    connection.sendTCP(
+                            SMSGChatMessageLobby.builder()
+                                    .unk(request.getUnk())
+                                    .sender(senderName)
+                                    .message(message)
+                                    .textColor(textColor)
+                                    .build()
+                    );
+                }
+        );
+    }
+
+    static CompletableFuture<String> messageForRecipient(
+            FTClient sender,
+            FTClient recipient,
+            String message,
+            LibreTranslateTranslationService translationService
+    ) {
+        if (recipient == sender || !recipient.isTranslateChatToEnglish()) {
+            return CompletableFuture.completedFuture(message);
+        }
+        return translationService.translateToEnglish(message);
     }
 }

--- a/game-server/src/main/java/com/jftse/emulator/server/core/handler/chat/ChatMessageRoomPacketHandler.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/handler/chat/ChatMessageRoomPacketHandler.java
@@ -12,6 +12,11 @@ import com.jftse.server.core.handler.PacketHandler;
 import com.jftse.server.core.handler.PacketId;
 import com.jftse.server.core.shared.packets.chat.CMSGChatMessageRoom;
 import com.jftse.server.core.shared.packets.chat.SMSGChatMessageRoom;
+import com.jftse.server.core.translation.ChatTranslationServices;
+import com.jftse.server.core.translation.LibreTranslateTranslationService;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BooleanSupplier;
 
 @PacketId(CMSGChatMessageRoom.PACKET_ID)
 public class ChatMessageRoomPacketHandler implements PacketHandler<FTConnection, CMSGChatMessageRoom> {
@@ -56,16 +61,99 @@ public class ChatMessageRoomPacketHandler implements PacketHandler<FTConnection,
 
                 boolean playerCanSeeMessage = areInSameTeam(senderPos, rp.getPosition()) || rp.getPosition() == MiscConstants.InvisibleGmSlot;
                 if (c.hasPlayer() && rp.getPlayerId() == c.getPlayer().getId() && playerCanSeeMessage) {
-                    c.getConnection().sendTCP(chatRoomMessage);
+                    sendMessage(
+                            c,
+                            client,
+                            chatRoomReqPacket,
+                            messageType,
+                            () -> isEligibleTeamRecipient(c, room, senderPos),
+                            translationService()
+                    );
                 }
             }
-            connection.sendTCP(chatRoomMessage); // Send to sender
+            sendMessage(
+                    client,
+                    client,
+                    chatRoomReqPacket,
+                    messageType,
+                    () -> client.getActiveRoom() == room,
+                    translationService()
+            );
         } else {
-            GameManager.getInstance().getClientsInRoom(room.getRoomId()).forEach(c -> c.getConnection().sendTCP(chatRoomMessage));
+            LibreTranslateTranslationService translationService = translationService();
+            GameManager.getInstance().getClientsInRoom(room.getRoomId()).forEach(recipient ->
+                    sendMessage(
+                            recipient,
+                            client,
+                            chatRoomReqPacket,
+                            messageType,
+                            () -> recipient.getActiveRoom() == room,
+                            translationService
+                    )
+            );
         }
     }
 
-    private boolean areInSameTeam(int playerPos1, int playerPos2) {
+    private static LibreTranslateTranslationService translationService() {
+        return ChatTranslationServices.get();
+    }
+
+    private static void sendMessage(
+            FTClient recipient,
+            FTClient sender,
+            CMSGChatMessageRoom request,
+            byte messageType,
+            BooleanSupplier stillEligible,
+            LibreTranslateTranslationService translationService
+    ) {
+        String senderName = sender.getPlayer().getName();
+        int textColor = sender.getTextMode();
+        long membershipGeneration = recipient.getRoomMembershipGeneration();
+        recipient.getChatDelivery().enqueue(
+                messageForRecipient(sender, recipient, request.getMessage(), translationService),
+                message -> {
+                    FTConnection connection = recipient.getConnection();
+                    if (recipient.getRoomMembershipGeneration() != membershipGeneration
+                            || !stillEligible.getAsBoolean()
+                            || connection == null) {
+                        return;
+                    }
+                    connection.sendTCP(
+                            SMSGChatMessageRoom.builder()
+                                    .type(messageType)
+                                    .sender(senderName)
+                                    .message(message)
+                                    .textColor(textColor)
+                                    .build()
+                    );
+                }
+        );
+    }
+
+    private static boolean isEligibleTeamRecipient(FTClient recipient, Room room, short senderPosition) {
+        if (recipient.getActiveRoom() != room || !recipient.hasPlayer()) {
+            return false;
+        }
+        RoomPlayer roomPlayer = recipient.getRoomPlayer();
+        return roomPlayer != null
+                && roomPlayer.getPlayerId() == recipient.getPlayer().getId()
+                && (areInSameTeam(senderPosition, roomPlayer.getPosition())
+                || roomPlayer.getPosition() == MiscConstants.InvisibleGmSlot);
+    }
+
+    static CompletableFuture<String> messageForRecipient(
+            FTClient sender,
+            FTClient recipient,
+            String message,
+            LibreTranslateTranslationService translationService
+    ) {
+        if (recipient == sender || !recipient.isTranslateChatToEnglish()) {
+            return CompletableFuture.completedFuture(message);
+        }
+        return translationService.translateToEnglish(message);
+    }
+
+    private static boolean areInSameTeam(int playerPos1, int playerPos2) {
         boolean bothInRedTeam = (playerPos1 == 0 && playerPos2 == 2) || (playerPos1 == 2 && playerPos2 == 0);
         boolean bothInBlueTeam = (playerPos1 == 1 && playerPos2 == 3) || (playerPos1 == 3 && playerPos2 == 1);
         return bothInRedTeam || bothInBlueTeam;

--- a/game-server/src/main/java/com/jftse/emulator/server/net/FTClient.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/net/FTClient.java
@@ -16,12 +16,14 @@ import com.jftse.server.core.constants.GameMode;
 import com.jftse.server.core.net.Client;
 import com.jftse.server.core.shared.PlayerLoadType;
 import com.jftse.server.core.shared.packets.game.SMSGReceiveData;
+import com.jftse.server.core.translation.OrderedChatDelivery;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Getter
@@ -37,12 +39,14 @@ public class FTClient extends Client<FTConnection> {
     private TutorialGame activeTutorialGame;
 
     private Room activeRoom;
+    private final AtomicLong roomMembershipGenerationCounter = new AtomicLong();
     private RoomPlayer roomPlayer;
     private Integer gameSessionId;
 
     private FruitManager fruitManager = new FruitManager();
 
     private volatile boolean inLobby = false;
+    private final AtomicLong lobbyMembershipGenerationCounter = new AtomicLong();
     private volatile boolean isSpectator = false;
 
     private volatile int lobbyGameModeTabFilter = GameMode.ALL;
@@ -68,6 +72,30 @@ public class FTClient extends Client<FTConnection> {
     private Pet activePet;
 
     private int textMode = 0;
+    private volatile boolean translateChatToEnglish = false;
+    private final OrderedChatDelivery chatDelivery = new OrderedChatDelivery();
+
+    public void setActiveRoom(Room activeRoom) {
+        if (this.activeRoom != activeRoom) {
+            roomMembershipGenerationCounter.incrementAndGet();
+        }
+        this.activeRoom = activeRoom;
+    }
+
+    public long getRoomMembershipGeneration() {
+        return roomMembershipGenerationCounter.get();
+    }
+
+    public void setInLobby(boolean inLobby) {
+        if (this.inLobby != inLobby) {
+            lobbyMembershipGenerationCounter.incrementAndGet();
+        }
+        this.inLobby = inLobby;
+    }
+
+    public long getLobbyMembershipGeneration() {
+        return lobbyMembershipGenerationCounter.get();
+    }
 
     public boolean updateDataRequestStep(int step) {
         boolean valid = dataRequestStep.compareAndSet(step - 1, step);
@@ -98,6 +126,7 @@ public class FTClient extends Client<FTConnection> {
         this.gameMaster = account.getGameMaster();
         this.accountStatus = account.getStatus();
         this.ap.set(account.getAp());
+        this.translateChatToEnglish = Boolean.TRUE.equals(player.getTranslateChatToEnglish());
         this.ftPlayer.set(loadPlayer(player, playerLoadType));
     }
 

--- a/game-server/src/main/resources/application.properties
+++ b/game-server/src/main/resources/application.properties
@@ -19,7 +19,7 @@ jftse.rabbitmq.exchange=fantasy-messenger
 jftse.rabbitmq.binding=system.motd game.messenger.# game.player.#
 jftse.rabbitmq.metrics.enabled=true
 
-grpc.server.port=9899
+grpc.server.port=${GRPC_SERVER_PORT:9899}
 
 grpc.client.GLOBAL.negotiation-type=plaintext
 grpc.client.auth-server.address=static://localhost:9898

--- a/game-server/src/test/java/com/jftse/emulator/server/core/command/ChatTranslationCommandIntegrationTest.java
+++ b/game-server/src/test/java/com/jftse/emulator/server/core/command/ChatTranslationCommandIntegrationTest.java
@@ -1,0 +1,188 @@
+package com.jftse.emulator.server.core.command;
+
+import com.jftse.emulator.server.core.client.FTPlayer;
+import com.jftse.emulator.server.core.command.commands.player.TranslateChatCommand;
+import com.jftse.emulator.server.core.life.room.Room;
+import com.jftse.emulator.server.core.manager.GameManager;
+import com.jftse.emulator.server.core.manager.ServiceManager;
+import com.jftse.emulator.server.core.packets.chat.S2CChatLobbyAnswerPacket;
+import com.jftse.emulator.server.core.packets.chat.S2CChatRoomAnswerPacket;
+import com.jftse.emulator.server.net.FTClient;
+import com.jftse.emulator.server.net.FTConnection;
+import com.jftse.entities.database.model.account.Account;
+import com.jftse.entities.database.model.player.Player;
+import com.jftse.entities.database.model.player.PlayerStatistic;
+import com.jftse.entities.database.model.pocket.Pocket;
+import com.jftse.server.core.protocol.IPacket;
+import com.jftse.server.core.service.CommandLogService;
+import com.jftse.server.core.service.PlayerService;
+import com.jftse.server.core.service.ScriptStateService;
+import com.jftse.server.core.shared.PlayerLoadType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ChatTranslationCommandIntegrationTest {
+    private Object previousGameManager;
+    private Object previousServiceManager;
+
+    private CommandManager commandManager;
+    private ServiceManager serviceManager;
+    private PlayerService playerService;
+    private FTConnection connection;
+    private FTClient client;
+    private Player player;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        GameManager gameManager = mock(GameManager.class);
+        serviceManager = mock(ServiceManager.class);
+        playerService = mock(PlayerService.class);
+
+        when(gameManager.getServiceManager()).thenReturn(serviceManager);
+        when(serviceManager.getCommandLogService()).thenReturn(mock(CommandLogService.class));
+        when(serviceManager.getPlayerService()).thenReturn(playerService);
+
+        previousGameManager = replaceStatic(GameManager.class, "instance", gameManager);
+        previousServiceManager = replaceStatic(ServiceManager.class, "instance", serviceManager);
+
+        commandManager = new CommandManager(mock(ScriptStateService.class));
+        commandManager.setRegisteredCommands(new LinkedHashMap<>());
+        commandManager.registerCommand("translate", 0, new TranslateChatCommand());
+
+        connection = mock(FTConnection.class);
+        client = mock(FTClient.class);
+        Account account = mock(Account.class);
+        FTPlayer ftPlayer = mock(FTPlayer.class);
+        player = new Player();
+
+        when(connection.getClient()).thenReturn(client);
+        when(client.getAccount()).thenReturn(account);
+        when(account.getGameMaster()).thenReturn(false);
+        when(client.hasPlayer()).thenReturn(true);
+        when(client.getPlayer()).thenReturn(ftPlayer);
+        when(ftPlayer.getPlayer()).thenReturn(player);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        replaceStatic(GameManager.class, "instance", previousGameManager);
+        replaceStatic(ServiceManager.class, "instance", previousServiceManager);
+    }
+
+    @Test
+    void dispatchesPostCommandArgumentAndPersistsPreference() {
+        commandManager.handle(connection, "-translate on");
+
+        verify(client).setTranslateChatToEnglish(true);
+        verify(playerService).save(player);
+    }
+
+    @Test
+    void normalizesCommandNameAndSurroundingWhitespace() {
+        assertTrue(commandManager.isCommand("  -TRANSLATE on  "));
+
+        commandManager.handle(connection, "  -TRANSLATE on  ");
+
+        verify(client).setTranslateChatToEnglish(true);
+        verify(playerService).save(player);
+    }
+
+    @Test
+    void persistsDisabledPreference() {
+        player.setTranslateChatToEnglish(true);
+
+        commandManager.handle(connection, "-translate off");
+
+        assertFalse(player.getTranslateChatToEnglish());
+        verify(client).setTranslateChatToEnglish(false);
+        verify(playerService).save(player);
+    }
+
+    @Test
+    void rollsBackAndReportsFailedPreferenceSave() {
+        doThrow(new RuntimeException("database unavailable")).when(playerService).save(player);
+
+        commandManager.handle(connection, "-translate on");
+
+        assertFalse(player.getTranslateChatToEnglish());
+        verify(client, never()).setTranslateChatToEnglish(true);
+        verify(connection).sendTCP(argThat((IPacket packet) ->
+                packet instanceof S2CChatLobbyAnswerPacket));
+    }
+
+    @Test
+    void invalidModeDoesNotChangeOrPersistPreference() {
+        commandManager.handle(connection, "-translate maybe");
+
+        verify(client, never()).setTranslateChatToEnglish(true);
+        verify(client, never()).setTranslateChatToEnglish(false);
+        verify(playerService, never()).save(player);
+    }
+
+    @Test
+    void roomCommandUsesRoomChatFeedback() {
+        when(client.getActiveRoom()).thenReturn(mock(Room.class));
+
+        commandManager.handle(connection, "-translate off");
+
+        verify(connection).sendTCP(argThat((IPacket packet) ->
+                packet instanceof S2CChatRoomAnswerPacket));
+    }
+
+    @Test
+    void freshClientRestoresPersistedPreference() {
+        Player persistedPlayer = new Player();
+        persistedPlayer.setId(1L);
+        persistedPlayer.setPlayerType((byte) 0);
+        Field preference = assertDoesNotThrow(
+                () -> Player.class.getDeclaredField("translateChatToEnglish"));
+        preference.setAccessible(true);
+        assertDoesNotThrow(() -> preference.set(persistedPlayer, true));
+
+        Account account = new Account();
+        account.setId(1L);
+        account.setAp(0);
+        account.setGameMaster(false);
+        account.setStatus(0);
+        persistedPlayer.setAccount(account);
+        Pocket pocket = new Pocket();
+        pocket.setId(1L);
+        persistedPlayer.setPocket(pocket);
+        PlayerStatistic statistic = new PlayerStatistic();
+        statistic.setId(1L);
+        persistedPlayer.setPlayerStatistic(statistic);
+
+        FTClient freshClient = new FTClient();
+        freshClient.loadPlayer(account, persistedPlayer, PlayerLoadType.BASIC);
+
+        assertTrue(freshClient.isTranslateChatToEnglish());
+    }
+
+    @Test
+    void newPlayerDefaultsToTranslationDisabled() {
+        FTClient freshClient = new FTClient();
+        assertFalse(freshClient.isTranslateChatToEnglish());
+    }
+
+    private static Object replaceStatic(Class<?> type, String fieldName, Object value) throws Exception {
+        Field field = type.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Object previous = field.get(null);
+        field.set(null, value);
+        return previous;
+    }
+}

--- a/game-server/src/test/java/com/jftse/emulator/server/core/handler/chat/ChatTranslationCharacterizationTest.java
+++ b/game-server/src/test/java/com/jftse/emulator/server/core/handler/chat/ChatTranslationCharacterizationTest.java
@@ -1,0 +1,148 @@
+package com.jftse.emulator.server.core.handler.chat;
+
+import com.jftse.emulator.server.net.FTClient;
+import com.jftse.server.core.translation.LibreTranslateTranslationService;
+import com.jftse.server.core.shared.packets.chat.SMSGChatMessageLobby;
+import com.jftse.server.core.shared.packets.chat.SMSGChatMessageRoom;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ChatTranslationCharacterizationTest {
+    private static final String THAI_MESSAGE = "มีใครอยากเล่นคู่ไหม";
+    private static final String ENGLISH_MESSAGE = "Does anyone want to play doubles?";
+
+    private HttpServer server;
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void preservesLobbyAndRoomPacketMetadata() {
+        SMSGChatMessageLobby lobby = SMSGChatMessageLobby.builder()
+                .unk((char) 7)
+                .sender("Somchai")
+                .message("มีใครอยากเล่นคู่ไหม")
+                .textColor(3)
+                .build();
+        SMSGChatMessageRoom room = SMSGChatMessageRoom.builder()
+                .type((byte) 1)
+                .sender("Somchai")
+                .message("มีใครอยากเล่นคู่ไหม")
+                .textColor(3)
+                .build();
+
+        assertEquals((char) 7, lobby.getUnk());
+        assertEquals("Somchai", lobby.getSender());
+        assertEquals("มีใครอยากเล่นคู่ไหม", lobby.getMessage());
+        assertEquals(3, lobby.getTextColor());
+        assertEquals((byte) 1, room.getType());
+        assertEquals("Somchai", room.getSender());
+        assertEquals("มีใครอยากเล่นคู่ไหม", room.getMessage());
+        assertEquals(3, room.getTextColor());
+    }
+
+    @Test
+    void preservesRoomTeamVisibilityRules() throws Exception {
+        ChatMessageRoomPacketHandler handler = new ChatMessageRoomPacketHandler();
+        Method areInSameTeam = ChatMessageRoomPacketHandler.class
+                .getDeclaredMethod("areInSameTeam", int.class, int.class);
+        areInSameTeam.setAccessible(true);
+
+        assertTrue((boolean) areInSameTeam.invoke(handler, 0, 2));
+        assertTrue((boolean) areInSameTeam.invoke(handler, 1, 3));
+        assertFalse((boolean) areInSameTeam.invoke(handler, 0, 1));
+        assertFalse((boolean) areInSameTeam.invoke(handler, 2, 3));
+    }
+
+    @Test
+    void routesOriginalToSenderAndThaiRecipientsAndTranslationToEnglishRecipients() throws Exception {
+        AtomicInteger providerCalls = new AtomicInteger();
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/translate", exchange -> {
+            providerCalls.incrementAndGet();
+            byte[] response = ("{\"translatedText\":\"" + ENGLISH_MESSAGE + "\"}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+
+        LibreTranslateTranslationService service = new LibreTranslateTranslationService(
+                HttpClient.newHttpClient(),
+                URI.create("http://127.0.0.1:" + server.getAddress().getPort() + "/translate"),
+                Duration.ofMillis(500),
+                true
+        );
+        FTClient sender = new FTClient();
+        FTClient thaiRecipient = new FTClient();
+        FTClient englishRecipientOne = new FTClient();
+        FTClient englishRecipientTwo = new FTClient();
+        Method setTranslation = FTClient.class.getMethod("setTranslateChatToEnglish", boolean.class);
+        setTranslation.invoke(sender, true);
+        setTranslation.invoke(englishRecipientOne, true);
+        setTranslation.invoke(englishRecipientTwo, true);
+
+        CompletableFuture<String> senderMessage = resolveMessage(
+                ChatMessageLobbyPacketHandler.class, sender, sender, service
+        );
+        CompletableFuture<String> thaiMessage = resolveMessage(
+                ChatMessageLobbyPacketHandler.class, sender, thaiRecipient, service
+        );
+        CompletableFuture<String> englishLobbyMessageOne = resolveMessage(
+                ChatMessageLobbyPacketHandler.class, sender, englishRecipientOne, service
+        );
+        CompletableFuture<String> englishLobbyMessageTwo = resolveMessage(
+                ChatMessageLobbyPacketHandler.class, sender, englishRecipientTwo, service
+        );
+        CompletableFuture<String> englishRoomMessage = resolveMessage(
+                ChatMessageRoomPacketHandler.class, sender, englishRecipientOne, service
+        );
+
+        assertEquals(THAI_MESSAGE, senderMessage.get(1, TimeUnit.SECONDS));
+        assertEquals(THAI_MESSAGE, thaiMessage.get(1, TimeUnit.SECONDS));
+        assertEquals(ENGLISH_MESSAGE, englishLobbyMessageOne.get(1, TimeUnit.SECONDS));
+        assertEquals(ENGLISH_MESSAGE, englishLobbyMessageTwo.get(1, TimeUnit.SECONDS));
+        assertEquals(ENGLISH_MESSAGE, englishRoomMessage.get(1, TimeUnit.SECONDS));
+        assertEquals(1, providerCalls.get());
+    }
+
+    @SuppressWarnings("unchecked")
+    private CompletableFuture<String> resolveMessage(
+            Class<?> handlerType,
+            FTClient sender,
+            FTClient recipient,
+            LibreTranslateTranslationService service
+    ) throws Exception {
+        Method resolver = handlerType.getDeclaredMethod(
+                "messageForRecipient",
+                FTClient.class,
+                FTClient.class,
+                String.class,
+                LibreTranslateTranslationService.class
+        );
+        resolver.setAccessible(true);
+        return (CompletableFuture<String>) resolver.invoke(null, sender, recipient, THAI_MESSAGE, service);
+    }
+}

--- a/game-server/src/test/java/com/jftse/emulator/server/core/handler/chat/ChatTranslationHandlerIntegrationTest.java
+++ b/game-server/src/test/java/com/jftse/emulator/server/core/handler/chat/ChatTranslationHandlerIntegrationTest.java
@@ -1,0 +1,329 @@
+package com.jftse.emulator.server.core.handler.chat;
+
+import com.jftse.emulator.server.core.client.FTPlayer;
+import com.jftse.emulator.server.core.command.CommandManager;
+import com.jftse.emulator.server.core.constants.RoomStatus;
+import com.jftse.emulator.server.core.life.room.Room;
+import com.jftse.emulator.server.core.life.room.RoomPlayer;
+import com.jftse.emulator.server.core.manager.GameManager;
+import com.jftse.emulator.server.net.FTClient;
+import com.jftse.emulator.server.net.FTConnection;
+import com.jftse.server.core.protocol.IPacket;
+import com.jftse.server.core.shared.packets.chat.CMSGChatMessageLobby;
+import com.jftse.server.core.shared.packets.chat.CMSGChatMessageRoom;
+import com.jftse.server.core.shared.packets.chat.SMSGChatMessageLobby;
+import com.jftse.server.core.shared.packets.chat.SMSGChatMessageRoom;
+import com.jftse.server.core.translation.ChatTranslationServices;
+import com.jftse.server.core.translation.LibreTranslateTranslationService;
+import com.jftse.server.core.translation.OrderedChatDelivery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ChatTranslationHandlerIntegrationTest {
+    private static final String THAI_FIRST = "ก ข้อความแรก";
+    private static final String THAI_SECOND = "ก ข้อความที่สอง";
+
+    private Object previousGameManager;
+    private Object previousCommandManager;
+    private LibreTranslateTranslationService previousTranslationService;
+
+    private GameManager gameManager;
+    private CommandManager commandManager;
+    private ControlledProvider provider;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        gameManager = mock(GameManager.class);
+        commandManager = mock(CommandManager.class);
+        when(commandManager.isCommand(anyString())).thenReturn(false);
+
+        previousGameManager = replaceStatic(GameManager.class, "instance", gameManager);
+        previousCommandManager = replaceStatic(CommandManager.class, "instance", commandManager);
+
+        previousTranslationService = ChatTranslationServices.get();
+        provider = new ControlledProvider();
+        ChatTranslationServices.configure(provider.service());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        provider.completeAll("{\"translatedText\":\"cleanup\"}");
+        ChatTranslationServices.configure(previousTranslationService);
+        replaceStatic(GameManager.class, "instance", previousGameManager);
+        replaceStatic(CommandManager.class, "instance", previousCommandManager);
+    }
+
+    @Test
+    void preservesPerRecipientOrderWhenTranslationsCompleteInReverse() {
+        Room room = runningRoom(7);
+        ClientFixture sender = client("Sender", 1L, (short) 0, room, false, false);
+        ClientFixture recipient = client("English", 2L, (short) 2, room, false, true);
+        when(gameManager.getClientsInRoom((short) 7)).thenReturn(List.of(recipient.client));
+
+        ChatMessageRoomPacketHandler handler = new ChatMessageRoomPacketHandler();
+        handler.handle(sender.connection, roomRequest((byte) 0, THAI_FIRST));
+        handler.handle(sender.connection, roomRequest((byte) 0, THAI_SECOND));
+
+        assertEquals(2, provider.pendingCount());
+        provider.complete(1, "{\"translatedText\":\"second\"}");
+        provider.complete(0, "{\"translatedText\":\"first\"}");
+
+        ArgumentCaptor<IPacket> packets = ArgumentCaptor.forClass(IPacket.class);
+        verify(recipient.connection, times(2)).sendTCP(packets.capture());
+        assertEquals(List.of("first", "second"), packets.getAllValues().stream()
+                .map(ChatTranslationHandlerIntegrationTest::roomMessage)
+                .toList());
+    }
+
+    @Test
+    void dropsDelayedLobbyMessageAfterRecipientLeavesLobby() {
+        AtomicBoolean recipientInLobby = new AtomicBoolean(true);
+        ClientFixture sender = client("Sender", 1L, (short) 0, null, true, false);
+        ClientFixture recipient = client("English", 2L, (short) 2, null, true, true);
+        when(recipient.client.isInLobby()).thenAnswer(invocation -> recipientInLobby.get());
+        when(gameManager.getClients()).thenReturn(
+                new ConcurrentLinkedDeque<>(List.of(recipient.client)));
+
+        new ChatMessageLobbyPacketHandler().handle(
+                sender.connection,
+                CMSGChatMessageLobby.builder().unk((char) 1).message(THAI_FIRST).build()
+        );
+        recipientInLobby.set(false);
+        provider.complete(0, "{\"translatedText\":\"first\"}");
+
+        verify(recipient.connection, never()).sendTCP(any(IPacket.class));
+    }
+
+    @Test
+    void dropsDelayedLobbyMessageAfterRecipientLeavesAndRejoins() {
+        ClientFixture sender = client("Sender", 1L, (short) 0, null, true, false);
+        ClientFixture recipient = client("English", 2L, (short) 2, null, true, true);
+        when(recipient.client.getLobbyMembershipGeneration()).thenReturn(1L, 3L);
+        when(gameManager.getClients()).thenReturn(
+                new ConcurrentLinkedDeque<>(List.of(recipient.client)));
+
+        new ChatMessageLobbyPacketHandler().handle(
+                sender.connection,
+                CMSGChatMessageLobby.builder().unk((char) 1).message(THAI_FIRST).build()
+        );
+        provider.complete(0, "{\"translatedText\":\"first\"}");
+
+        verify(recipient.connection, never()).sendTCP(any(IPacket.class));
+    }
+
+    @Test
+    void dropsDelayedRoomMessageAfterRecipientLeavesAndRejoins() {
+        Room room = runningRoom(8);
+        ClientFixture sender = client("Sender", 1L, (short) 0, room, false, false);
+        ClientFixture recipient = client("English", 2L, (short) 2, room, false, true);
+        when(recipient.client.getRoomMembershipGeneration()).thenReturn(1L, 3L);
+        when(gameManager.getClientsInRoom((short) 8)).thenReturn(List.of(recipient.client));
+
+        new ChatMessageRoomPacketHandler().handle(
+                sender.connection,
+                roomRequest((byte) 0, THAI_FIRST)
+        );
+        provider.complete(0, "{\"translatedText\":\"first\"}");
+
+        verify(recipient.connection, never()).sendTCP(any(IPacket.class));
+    }
+
+    @Test
+    void runningTeamChatUsesActualHandlerAndPreservesVisibility() {
+        Room room = runningRoom(9);
+        ClientFixture sender = client("Sender", 1L, (short) 0, room, false, false);
+        ClientFixture teammate = client("Teammate", 2L, (short) 2, room, false, true);
+        ClientFixture opponent = client("Opponent", 3L, (short) 1, room, false, true);
+        when(gameManager.getClientsInRoom((short) 9))
+                .thenReturn(List.of(sender.client, teammate.client, opponent.client));
+
+        new ChatMessageRoomPacketHandler().handle(
+                sender.connection,
+                roomRequest((byte) 1, THAI_FIRST)
+        );
+        provider.complete(0, "{\"translatedText\":\"team message\"}");
+
+        assertEquals(RoomStatus.Running, room.getStatus());
+        verify(sender.connection).sendTCP(any(IPacket.class));
+        ArgumentCaptor<IPacket> packet = ArgumentCaptor.forClass(IPacket.class);
+        verify(teammate.connection).sendTCP(packet.capture());
+        assertEquals("team message", roomMessage(packet.getValue()));
+        verify(opponent.connection, never()).sendTCP(any(IPacket.class));
+    }
+
+    @Test
+    void lobbyHandlerSendsOriginalAndTranslatedPackets() {
+        ClientFixture sender = client("Sender", 1L, (short) 0, null, true, false);
+        ClientFixture thaiRecipient = client("Thai", 2L, (short) 2, null, true, false);
+        ClientFixture englishRecipient = client("English", 3L, (short) 1, null, true, true);
+        when(gameManager.getClients()).thenReturn(new ConcurrentLinkedDeque<>(
+                List.of(sender.client, thaiRecipient.client, englishRecipient.client)));
+
+        new ChatMessageLobbyPacketHandler().handle(
+                sender.connection,
+                CMSGChatMessageLobby.builder().unk((char) 1).message(THAI_FIRST).build()
+        );
+        provider.complete(0, "{\"translatedText\":\"translated\"}");
+
+        ArgumentCaptor<IPacket> senderPacket = ArgumentCaptor.forClass(IPacket.class);
+        verify(sender.connection).sendTCP(senderPacket.capture());
+        assertEquals(THAI_FIRST, lobbyMessage(senderPacket.getValue()));
+
+        ArgumentCaptor<IPacket> thaiPacket = ArgumentCaptor.forClass(IPacket.class);
+        verify(thaiRecipient.connection).sendTCP(thaiPacket.capture());
+        assertEquals(THAI_FIRST, lobbyMessage(thaiPacket.getValue()));
+
+        ArgumentCaptor<IPacket> englishPacket = ArgumentCaptor.forClass(IPacket.class);
+        verify(englishRecipient.connection).sendTCP(englishPacket.capture());
+        assertEquals("translated", lobbyMessage(englishPacket.getValue()));
+    }
+
+    @Test
+    void commandShortCircuitsProviderAndBroadcast() {
+        ClientFixture sender = client("Sender", 1L, (short) 0, null, true, false);
+        ClientFixture other = client("Other", 2L, (short) 2, null, true, true);
+        when(gameManager.getClients()).thenReturn(
+                new ConcurrentLinkedDeque<>(List.of(sender.client, other.client)));
+        when(commandManager.isCommand("-translate on")).thenReturn(true);
+
+        new ChatMessageLobbyPacketHandler().handle(
+                sender.connection,
+                CMSGChatMessageLobby.builder().unk((char) 1).message("-translate on").build()
+        );
+
+        verify(commandManager).handle(sender.connection, "-translate on");
+        verify(sender.connection).sendTCP(any(IPacket.class));
+        verify(other.connection, never()).sendTCP(any(IPacket.class));
+        assertEquals(0, provider.requestCount);
+    }
+
+    private static Room runningRoom(int roomId) {
+        Room room = new Room();
+        room.setRoomId((short) roomId);
+        room.setStatus(RoomStatus.Running);
+        return room;
+    }
+
+    private static CMSGChatMessageRoom roomRequest(byte type, String message) {
+        return CMSGChatMessageRoom.builder().type(type).message(message).build();
+    }
+
+    private static ClientFixture client(
+            String name,
+            long id,
+            short position,
+            Room room,
+            boolean inLobby,
+            boolean translate
+    ) {
+        FTClient client = mock(FTClient.class);
+        FTConnection connection = mock(FTConnection.class);
+        FTPlayer player = mock(FTPlayer.class);
+        RoomPlayer roomPlayer = mock(RoomPlayer.class);
+
+        when(connection.getClient()).thenReturn(client);
+        when(client.getConnection()).thenReturn(connection);
+        when(client.hasPlayer()).thenReturn(true);
+        when(client.getPlayer()).thenReturn(player);
+        when(client.getRoomPlayer()).thenReturn(roomPlayer);
+        when(client.getActiveRoom()).thenReturn(room);
+        when(client.isInLobby()).thenReturn(inLobby);
+        when(client.isTranslateChatToEnglish()).thenReturn(translate);
+        when(client.getChatDelivery()).thenReturn(new OrderedChatDelivery());
+        when(player.getName()).thenReturn(name);
+        when(player.getId()).thenReturn(id);
+        when(roomPlayer.getPlayerId()).thenReturn(id);
+        when(roomPlayer.getPosition()).thenReturn(position);
+        return new ClientFixture(client, connection);
+    }
+
+    private static String lobbyMessage(IPacket packet) {
+        return ((SMSGChatMessageLobby) packet).getMessage();
+    }
+
+    private static String roomMessage(IPacket packet) {
+        return ((SMSGChatMessageRoom) packet).getMessage();
+    }
+
+    private static Object replaceStatic(Class<?> type, String fieldName, Object value) throws Exception {
+        Field field = type.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Object previous = field.get(null);
+        field.set(null, value);
+        return previous;
+    }
+
+    private record ClientFixture(FTClient client, FTConnection connection) {
+    }
+
+    private static final class ControlledProvider {
+        private final HttpClient client = mock(HttpClient.class);
+        private final List<CompletableFuture<HttpResponse<String>>> pending = new ArrayList<>();
+        private int requestCount;
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        private ControlledProvider() {
+            when(client.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                    .thenAnswer(invocation -> {
+                        requestCount++;
+                        CompletableFuture<HttpResponse<String>> response = new CompletableFuture<>();
+                        pending.add(response);
+                        return response;
+                    });
+        }
+
+        private LibreTranslateTranslationService service() {
+            return new LibreTranslateTranslationService(
+                    client,
+                    URI.create("http://provider.invalid/translate"),
+                    Duration.ofSeconds(5),
+                    true
+            );
+        }
+
+        private int pendingCount() {
+            return pending.size();
+        }
+
+        private void complete(int index, String body) {
+            CompletableFuture<HttpResponse<String>> future = pending.get(index);
+            HttpResponse<String> response = mock(HttpResponse.class);
+            when(response.statusCode()).thenReturn(200);
+            when(response.body()).thenReturn(body);
+            future.complete(response);
+        }
+
+        private void completeAll(String body) {
+            for (int index = 0; index < pending.size(); index++) {
+                if (!pending.get(index).isDone()) {
+                    complete(index, body);
+                }
+            }
+        }
+    }
+}

--- a/server-core/pom.xml
+++ b/server-core/pom.xml
@@ -18,6 +18,9 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <java.version>21</java.version>
+        <git.commit.id.abbrev>unknown</git.commit.id.abbrev>
+        <git.commit.time>unknown</git.commit.time>
+        <git.branch>unknown</git.branch>
     </properties>
 
     <dependencies>
@@ -80,6 +83,11 @@
             <groupId>org.springframework.amqp</groupId>
             <artifactId>spring-rabbit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -128,6 +136,7 @@
                 <version>4.9.10</version>
                 <configuration>
                     <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
                     <generateGitPropertiesFile>false</generateGitPropertiesFile>
                     <includeOnlyProperties>
                         <includeOnlyProperty>git.commit.id.abbrev</includeOnlyProperty>

--- a/server-core/src/main/java/com/jftse/server/core/shared/ServerConfService.java
+++ b/server-core/src/main/java/com/jftse/server/core/shared/ServerConfService.java
@@ -70,7 +70,18 @@ public class ServerConfService {
 
     public <T> T get(String key, Class<T> type) {
         String value = getString(key);
+        return cast(value, type);
+    }
 
+    public <T> T get(String key, Class<T> type, T defaultValue) {
+        String value = System.getenv(key);
+        if (value == null) {
+            value = props.getProperty(key);
+        }
+        return value == null ? defaultValue : cast(value, type);
+    }
+
+    private <T> T cast(String value, Class<T> type) {
         Object castedValue;
         if (type == Integer.class) {
             castedValue = Integer.parseInt(value);

--- a/server-core/src/main/java/com/jftse/server/core/translation/ChatTranslationServices.java
+++ b/server-core/src/main/java/com/jftse/server/core/translation/ChatTranslationServices.java
@@ -1,0 +1,27 @@
+package com.jftse.server.core.translation;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.Objects;
+
+public final class ChatTranslationServices {
+    private static volatile LibreTranslateTranslationService service =
+            new LibreTranslateTranslationService(
+                    HttpClient.newHttpClient(),
+                    URI.create("http://127.0.0.1:5000/translate"),
+                    Duration.ofMillis(450),
+                    false
+            );
+
+    private ChatTranslationServices() {
+    }
+
+    public static LibreTranslateTranslationService get() {
+        return service;
+    }
+
+    public static void configure(LibreTranslateTranslationService translationService) {
+        service = Objects.requireNonNull(translationService);
+    }
+}

--- a/server-core/src/main/java/com/jftse/server/core/translation/LibreTranslateTranslationService.java
+++ b/server-core/src/main/java/com/jftse/server/core/translation/LibreTranslateTranslationService.java
@@ -31,7 +31,7 @@ public final class LibreTranslateTranslationService {
     static final int MAX_INPUT_BYTES = 1024;
     static final int MAX_TRANSLATED_CODE_POINTS = 1024;
     static final int MAX_RESPONSE_BYTES = 16_384;
-    static final int MAX_CONCURRENT_REQUESTS = 2;
+    public static final int DEFAULT_MAX_CONCURRENT_REQUESTS = 2;
 
     private final HttpClient httpClient;
     private final URI endpoint;
@@ -63,7 +63,7 @@ public final class LibreTranslateTranslationService {
                 enabled,
                 MAX_INPUT_CODE_POINTS,
                 MAX_TRANSLATED_CODE_POINTS,
-                MAX_CONCURRENT_REQUESTS
+                DEFAULT_MAX_CONCURRENT_REQUESTS
         );
     }
 

--- a/server-core/src/main/java/com/jftse/server/core/translation/LibreTranslateTranslationService.java
+++ b/server-core/src/main/java/com/jftse/server/core/translation/LibreTranslateTranslationService.java
@@ -31,7 +31,7 @@ public final class LibreTranslateTranslationService {
     static final int MAX_INPUT_BYTES = 1024;
     static final int MAX_TRANSLATED_CODE_POINTS = 1024;
     static final int MAX_RESPONSE_BYTES = 16_384;
-    static final int MAX_CONCURRENT_REQUESTS = 8;
+    static final int MAX_CONCURRENT_REQUESTS = 2;
 
     private final HttpClient httpClient;
     private final URI endpoint;

--- a/server-core/src/main/java/com/jftse/server/core/translation/LibreTranslateTranslationService.java
+++ b/server-core/src/main/java/com/jftse/server/core/translation/LibreTranslateTranslationService.java
@@ -1,0 +1,267 @@
+package com.jftse.server.core.translation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import lombok.extern.log4j.Log4j2;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Flow;
+import java.util.concurrent.Semaphore;
+
+@Log4j2
+public final class LibreTranslateTranslationService {
+    static final int MAX_INPUT_CODE_POINTS = 256;
+    static final int MAX_INPUT_BYTES = 1024;
+    static final int MAX_TRANSLATED_CODE_POINTS = 1024;
+    static final int MAX_RESPONSE_BYTES = 16_384;
+    static final int MAX_CONCURRENT_REQUESTS = 8;
+
+    private final HttpClient httpClient;
+    private final URI endpoint;
+    private final Duration timeout;
+    private final boolean enabled;
+    private final int maximumInputCodePoints;
+    private final int maximumTranslatedCodePoints;
+    private final Semaphore requestPermits;
+    private final Map<String, String> translations = Collections.synchronizedMap(
+            new LinkedHashMap<>(128, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+                    return size() > 512;
+                }
+            }
+    );
+    private final ConcurrentMap<String, CompletableFuture<String>> inFlightTranslations = new ConcurrentHashMap<>();
+
+    public LibreTranslateTranslationService(
+            HttpClient httpClient,
+            URI endpoint,
+            Duration timeout,
+            boolean enabled
+    ) {
+        this(
+                httpClient,
+                endpoint,
+                timeout,
+                enabled,
+                MAX_INPUT_CODE_POINTS,
+                MAX_TRANSLATED_CODE_POINTS,
+                MAX_CONCURRENT_REQUESTS
+        );
+    }
+
+    public LibreTranslateTranslationService(
+            HttpClient httpClient,
+            URI endpoint,
+            Duration timeout,
+            boolean enabled,
+            int maximumInputCodePoints,
+            int maximumTranslatedCodePoints,
+            int maximumConcurrentRequests
+    ) {
+        this.httpClient = httpClient;
+        this.endpoint = endpoint;
+        this.timeout = timeout;
+        this.enabled = enabled;
+        this.maximumInputCodePoints = requirePositive(
+                maximumInputCodePoints,
+                "maximumInputCodePoints"
+        );
+        this.maximumTranslatedCodePoints = requirePositive(
+                maximumTranslatedCodePoints,
+                "maximumTranslatedCodePoints"
+        );
+        this.requestPermits = new Semaphore(requirePositive(
+                maximumConcurrentRequests,
+                "maximumConcurrentRequests"
+        ));
+    }
+
+    public CompletableFuture<String> translateToEnglish(String message) {
+        if (!enabled || !containsThai(message) || exceedsInputLimit(message)) {
+            return CompletableFuture.completedFuture(message);
+        }
+
+        String cachedTranslation = translations.get(message);
+        if (cachedTranslation != null) {
+            return CompletableFuture.completedFuture(cachedTranslation);
+        }
+
+        CompletableFuture<String> existing = inFlightTranslations.get(message);
+        if (existing != null) {
+            return existing;
+        }
+        if (!requestPermits.tryAcquire()) {
+            return CompletableFuture.completedFuture(message);
+        }
+
+        CompletableFuture<String> result = new CompletableFuture<>();
+        existing = inFlightTranslations.putIfAbsent(message, result);
+        if (existing != null) {
+            requestPermits.release();
+            return existing;
+        }
+
+        try {
+            requestTranslation(message).whenComplete((translation, failure) ->
+                    completeTranslation(message, result, translation, failure)
+            );
+        } catch (RuntimeException failure) {
+            completeTranslation(message, result, null, failure);
+        }
+        return result;
+    }
+
+    private CompletableFuture<String> requestTranslation(String message) {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("q", message);
+        payload.addProperty("source", "th");
+        payload.addProperty("target", "en");
+        payload.addProperty("format", "text");
+
+        HttpRequest request = HttpRequest.newBuilder(endpoint)
+                .timeout(timeout)
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+                .build();
+
+        return httpClient.sendAsync(request, limitedStringBodyHandler())
+                .thenApply(this::readTranslation);
+    }
+
+    private void completeTranslation(
+            String message,
+            CompletableFuture<String> result,
+            String translation,
+            Throwable failure
+    ) {
+        try {
+            if (failure != null) {
+                log.warn("Chat translation failed; sending original message: {}", failure.getMessage());
+                result.complete(message);
+                return;
+            }
+            translations.put(message, translation);
+            result.complete(translation);
+        } finally {
+            inFlightTranslations.remove(message, result);
+            requestPermits.release();
+        }
+    }
+
+    private String readTranslation(HttpResponse<String> response) {
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new CompletionException(
+                    new IOException("LibreTranslate returned HTTP " + response.statusCode())
+            );
+        }
+
+        try {
+            JsonElement translatedText = JsonParser.parseString(response.body())
+                    .getAsJsonObject()
+                    .get("translatedText");
+            if (translatedText == null || !translatedText.isJsonPrimitive()) {
+                throw new IOException("LibreTranslate response is missing translatedText");
+            }
+            String translation = translatedText.getAsString();
+            if (translation.isBlank()
+                    || translation.codePointCount(0, translation.length()) > maximumTranslatedCodePoints) {
+                throw new IOException("LibreTranslate response exceeds translated-text limit");
+            }
+            return translation;
+        } catch (RuntimeException | IOException exception) {
+            throw new CompletionException(exception);
+        }
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    private boolean containsThai(String message) {
+        return message.codePoints().anyMatch(codePoint -> codePoint >= 0x0E00 && codePoint <= 0x0E7F);
+    }
+
+    private boolean exceedsInputLimit(String message) {
+        return message.codePointCount(0, message.length()) > maximumInputCodePoints
+                || message.getBytes(StandardCharsets.UTF_8).length > MAX_INPUT_BYTES;
+    }
+
+    private static int requirePositive(int value, String name) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(name + " must be positive");
+        }
+        return value;
+    }
+
+    private static HttpResponse.BodyHandler<String> limitedStringBodyHandler() {
+        return responseInfo -> new LimitedStringSubscriber(MAX_RESPONSE_BYTES);
+    }
+
+    private static final class LimitedStringSubscriber implements HttpResponse.BodySubscriber<String> {
+        private final int maximumBytes;
+        private final ByteArrayOutputStream body;
+        private final CompletableFuture<String> result = new CompletableFuture<>();
+        private Flow.Subscription subscription;
+
+        private LimitedStringSubscriber(int maximumBytes) {
+            this.maximumBytes = maximumBytes;
+            this.body = new ByteArrayOutputStream(Math.min(maximumBytes, 1024));
+        }
+
+        @Override
+        public CompletableFuture<String> getBody() {
+            return result;
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            this.subscription = subscription;
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(List<ByteBuffer> buffers) {
+            for (ByteBuffer buffer : buffers) {
+                if (body.size() + buffer.remaining() > maximumBytes) {
+                    subscription.cancel();
+                    result.completeExceptionally(
+                            new IOException("LibreTranslate response exceeds body limit")
+                    );
+                    return;
+                }
+                byte[] bytes = new byte[buffer.remaining()];
+                buffer.get(bytes);
+                body.writeBytes(bytes);
+            }
+        }
+
+        @Override
+        public void onError(Throwable failure) {
+            result.completeExceptionally(failure);
+        }
+
+        @Override
+        public void onComplete() {
+            result.complete(body.toString(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/server-core/src/main/java/com/jftse/server/core/translation/OrderedChatDelivery.java
+++ b/server-core/src/main/java/com/jftse/server/core/translation/OrderedChatDelivery.java
@@ -1,0 +1,26 @@
+package com.jftse.server.core.translation;
+
+import lombok.extern.log4j.Log4j2;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
+
+@Log4j2
+public final class OrderedChatDelivery {
+    private CompletableFuture<Void> tail = CompletableFuture.completedFuture(null);
+
+    public synchronized void enqueue(
+            CompletionStage<String> message,
+            Consumer<String> delivery
+    ) {
+        CompletableFuture<Void> previous = tail.handle((ignored, failure) -> null);
+        tail = previous
+                .thenCombine(message, (ignored, text) -> text)
+                .thenAccept(delivery)
+                .exceptionally(failure -> {
+                    log.warn("Unable to deliver ordered chat message: {}", failure.getMessage());
+                    return null;
+                });
+    }
+}

--- a/server-core/src/test/java/com/jftse/server/core/translation/LibreTranslateTranslationServiceTest.java
+++ b/server-core/src/test/java/com/jftse/server/core/translation/LibreTranslateTranslationServiceTest.java
@@ -1,0 +1,295 @@
+package com.jftse.server.core.translation;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LibreTranslateTranslationServiceTest {
+    private static final String THAI_MESSAGE = "มีใครอยากเล่นคู่ไหม";
+    private static final String ENGLISH_MESSAGE = "Does anyone want to play doubles?";
+
+    private HttpServer server;
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void translatesThaiMessageThroughLibreTranslateContract() throws Exception {
+        AtomicReference<String> requestBody = new AtomicReference<>();
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/translate", exchange -> {
+            requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            byte[] response = ("{\"translatedText\":\"" + ENGLISH_MESSAGE + "\"}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+
+        Object service = createService(server.getAddress().getPort(), Duration.ofMillis(500), true);
+        String translated = translate(service, THAI_MESSAGE).get(1, TimeUnit.SECONDS);
+
+        assertEquals(ENGLISH_MESSAGE, translated);
+        assertTrue(requestBody.get().contains("\"q\":\"" + THAI_MESSAGE + "\""));
+        assertTrue(requestBody.get().contains("\"source\":\"th\""));
+        assertTrue(requestBody.get().contains("\"target\":\"en\""));
+    }
+
+    @Test
+    void skipsProviderWhenDisabledOrMessageContainsNoThai() throws Exception {
+        AtomicInteger providerCalls = new AtomicInteger();
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/translate", exchange -> {
+            providerCalls.incrementAndGet();
+            exchange.sendResponseHeaders(500, -1);
+            exchange.close();
+        });
+        server.start();
+
+        Object disabled = createService(server.getAddress().getPort(), Duration.ofMillis(500), false);
+        Object enabled = createService(server.getAddress().getPort(), Duration.ofMillis(500), true);
+
+        assertEquals(THAI_MESSAGE, translate(disabled, THAI_MESSAGE).get(1, TimeUnit.SECONDS));
+        assertEquals("ready for doubles", translate(enabled, "ready for doubles").get(1, TimeUnit.SECONDS));
+        assertEquals(0, providerCalls.get());
+    }
+
+    @Test
+    void returnsOriginalMessageForMalformedProviderResponse() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/translate", exchange -> {
+            byte[] response = "{}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+
+        Object service = createService(server.getAddress().getPort(), Duration.ofMillis(500), true);
+
+        assertEquals(THAI_MESSAGE, translate(service, THAI_MESSAGE).get(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void returnsOriginalMessageWhenProviderExceedsTimeout() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/translate", exchange -> {
+            exchange.getRequestBody().readAllBytes();
+        });
+        server.start();
+
+        Object service = createService(server.getAddress().getPort(), Duration.ofMillis(50), true);
+
+        assertEquals(THAI_MESSAGE, translate(service, THAI_MESSAGE).get(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void rejectsOversizedThaiBeforeCallingProvider() throws Exception {
+        ControlledProvider provider = new ControlledProvider();
+        LibreTranslateTranslationService service = new LibreTranslateTranslationService(
+                provider.client,
+                URI.create("http://provider.invalid/translate"),
+                Duration.ofMillis(500),
+                true
+        );
+        String oversized = "ก".repeat(257);
+
+        CompletableFuture<String> result = service.translateToEnglish(oversized);
+        try {
+            assertEquals(0, provider.requestCount.get());
+            assertEquals(oversized, result.get(1, TimeUnit.SECONDS));
+        } finally {
+            provider.completeAll("{\"translatedText\":\"unused\"}");
+        }
+    }
+
+    @Test
+    void capsConcurrentUniqueProviderRequests() {
+        ControlledProvider provider = new ControlledProvider();
+        LibreTranslateTranslationService service = new LibreTranslateTranslationService(
+                provider.client,
+                URI.create("http://provider.invalid/translate"),
+                Duration.ofSeconds(5),
+                true
+        );
+        List<CompletableFuture<String>> results = new ArrayList<>();
+
+        for (int index = 0; index < 12; index++) {
+            results.add(service.translateToEnglish(THAI_MESSAGE + index));
+        }
+
+        try {
+            assertEquals(8, provider.requestCount.get());
+        } finally {
+            provider.completeAll("{\"translatedText\":\"translated\"}");
+        }
+    }
+
+    @Test
+    void rejectsOversizedProviderResponse() throws Exception {
+        ControlledProvider provider = new ControlledProvider();
+        LibreTranslateTranslationService service = new LibreTranslateTranslationService(
+                provider.client,
+                URI.create("http://provider.invalid/translate"),
+                Duration.ofMillis(500),
+                true
+        );
+
+        CompletableFuture<String> result = service.translateToEnglish(THAI_MESSAGE);
+        provider.completeNext("{\"translatedText\":\"" + "x".repeat(1025) + "\"}");
+
+        assertEquals(THAI_MESSAGE, result.get(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void releasesConcurrencyPermitsAfterRequestsComplete() throws Exception {
+        ControlledProvider provider = new ControlledProvider();
+        LibreTranslateTranslationService service = new LibreTranslateTranslationService(
+                provider.client,
+                URI.create("http://provider.invalid/translate"),
+                Duration.ofSeconds(5),
+                true
+        );
+        List<CompletableFuture<String>> firstBatch = new ArrayList<>();
+        for (int index = 0; index < 8; index++) {
+            firstBatch.add(service.translateToEnglish(THAI_MESSAGE + index));
+        }
+        provider.completeAll("{\"translatedText\":\"translated\"}");
+        CompletableFuture.allOf(firstBatch.toArray(CompletableFuture[]::new))
+                .get(1, TimeUnit.SECONDS);
+
+        CompletableFuture<String> next = service.translateToEnglish(THAI_MESSAGE + "next");
+        assertEquals(9, provider.requestCount.get());
+        provider.completeNext("{\"translatedText\":\"next\"}");
+        assertEquals("next", next.get(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void honorsConfiguredInputOutputAndConcurrencyBounds() throws Exception {
+        ControlledProvider provider = new ControlledProvider();
+        LibreTranslateTranslationService service = new LibreTranslateTranslationService(
+                provider.client,
+                URI.create("http://provider.invalid/translate"),
+                Duration.ofMillis(500),
+                true,
+                1,
+                3,
+                1
+        );
+
+        assertEquals("กก", service.translateToEnglish("กก").get(1, TimeUnit.SECONDS));
+        assertEquals(0, provider.requestCount.get());
+
+        CompletableFuture<String> first = service.translateToEnglish("ก");
+        assertEquals("ข", service.translateToEnglish("ข").get(1, TimeUnit.SECONDS));
+        assertEquals(1, provider.requestCount.get());
+
+        provider.completeNext("{\"translatedText\":\"four\"}");
+        assertEquals("ก", first.get(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void evictsLeastRecentlyUsedTranslationAfter512Entries() throws Exception {
+        ControlledProvider provider = new ControlledProvider();
+        LibreTranslateTranslationService service = new LibreTranslateTranslationService(
+                provider.client,
+                URI.create("http://provider.invalid/translate"),
+                Duration.ofSeconds(5),
+                true
+        );
+
+        for (int index = 0; index < 513; index++) {
+            CompletableFuture<String> result = service.translateToEnglish(THAI_MESSAGE + index);
+            provider.completeNext("{\"translatedText\":\"translation-" + index + "\"}");
+            assertEquals("translation-" + index, result.get(1, TimeUnit.SECONDS));
+        }
+
+        CompletableFuture<String> evicted = service.translateToEnglish(THAI_MESSAGE + 0);
+        assertEquals(514, provider.requestCount.get());
+        provider.completeNext("{\"translatedText\":\"reloaded\"}");
+        assertEquals("reloaded", evicted.get(1, TimeUnit.SECONDS));
+    }
+
+    private Object createService(int port, Duration timeout, boolean enabled) throws Exception {
+        Class<?> serviceType = Class.forName(
+                "com.jftse.server.core.translation.LibreTranslateTranslationService"
+        );
+        Constructor<?> constructor = serviceType.getConstructor(
+                HttpClient.class,
+                URI.class,
+                Duration.class,
+                boolean.class
+        );
+        return constructor.newInstance(
+                HttpClient.newHttpClient(),
+                URI.create("http://127.0.0.1:" + port + "/translate"),
+                timeout,
+                enabled
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private CompletableFuture<String> translate(Object service, String message) throws Exception {
+        Method translate = service.getClass().getMethod("translateToEnglish", String.class);
+        return (CompletableFuture<String>) translate.invoke(service, message);
+    }
+
+    private static final class ControlledProvider {
+        private final HttpClient client = mock(HttpClient.class);
+        private final AtomicInteger requestCount = new AtomicInteger();
+        private final List<CompletableFuture<HttpResponse<String>>> pending = new ArrayList<>();
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        private ControlledProvider() {
+            when(client.sendAsync(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                    .thenAnswer(invocation -> {
+                        requestCount.incrementAndGet();
+                        CompletableFuture<HttpResponse<String>> response = new CompletableFuture<>();
+                        pending.add(response);
+                        return response;
+                    });
+        }
+
+        private void completeNext(String body) {
+            CompletableFuture<HttpResponse<String>> future = pending.remove(0);
+            HttpResponse<String> response = mock(HttpResponse.class);
+            when(response.statusCode()).thenReturn(200);
+            when(response.body()).thenReturn(body);
+            future.complete(response);
+        }
+
+        private void completeAll(String body) {
+            while (!pending.isEmpty()) {
+                completeNext(body);
+            }
+        }
+    }
+}

--- a/server-core/src/test/java/com/jftse/server/core/translation/LibreTranslateTranslationServiceTest.java
+++ b/server-core/src/test/java/com/jftse/server/core/translation/LibreTranslateTranslationServiceTest.java
@@ -250,6 +250,58 @@ class LibreTranslateTranslationServiceTest {
     }
 
     @Test
+    void coalescesOneHundredConcurrentRecipientsIntoOneProviderRequest() throws Exception {
+        ControlledProvider provider = new ControlledProvider();
+        LibreTranslateTranslationService service = new LibreTranslateTranslationService(
+                provider.client,
+                URI.create("http://provider.invalid/translate"),
+                Duration.ofMillis(500),
+                true,
+                LibreTranslateTranslationService.MAX_INPUT_CODE_POINTS,
+                LibreTranslateTranslationService.MAX_TRANSLATED_CODE_POINTS,
+                100
+        );
+        List<CompletableFuture<String>> recipients = new ArrayList<>();
+
+        for (int index = 0; index < 100; index++) {
+            recipients.add(service.translateToEnglish(THAI_MESSAGE));
+        }
+
+        assertEquals(1, provider.requestCount.get());
+        provider.completeNext("{\"translatedText\":\"hello\"}");
+        CompletableFuture.allOf(recipients.toArray(CompletableFuture[]::new))
+                .get(1, TimeUnit.SECONDS);
+        assertTrue(recipients.stream().allMatch(result -> "hello".equals(result.join())));
+    }
+
+    @Test
+    void failsOpenNinetyEightOfOneHundredSimultaneousUniqueMessages() throws Exception {
+        ControlledProvider provider = new ControlledProvider();
+        LibreTranslateTranslationService service = new LibreTranslateTranslationService(
+                provider.client,
+                URI.create("http://provider.invalid/translate"),
+                Duration.ofMillis(500),
+                true
+        );
+        List<CompletableFuture<String>> messages = new ArrayList<>();
+
+        for (int index = 0; index < 100; index++) {
+            messages.add(service.translateToEnglish(THAI_MESSAGE + index));
+        }
+
+        assertEquals(2, provider.requestCount.get());
+        for (int index = 2; index < 100; index++) {
+            assertEquals(THAI_MESSAGE + index, messages.get(index).get(1, TimeUnit.SECONDS));
+        }
+
+        provider.completeAll("{\"translatedText\":\"hello\"}");
+        CompletableFuture.allOf(messages.toArray(CompletableFuture[]::new))
+                .get(1, TimeUnit.SECONDS);
+        assertEquals("hello", messages.get(0).join());
+        assertEquals("hello", messages.get(1).join());
+    }
+
+    @Test
     void evictsLeastRecentlyUsedTranslationAfter512Entries() throws Exception {
         ControlledProvider provider = new ControlledProvider();
         LibreTranslateTranslationService service = new LibreTranslateTranslationService(

--- a/server-core/src/test/java/com/jftse/server/core/translation/LibreTranslateTranslationServiceTest.java
+++ b/server-core/src/test/java/com/jftse/server/core/translation/LibreTranslateTranslationServiceTest.java
@@ -138,7 +138,10 @@ class LibreTranslateTranslationServiceTest {
                 provider.client,
                 URI.create("http://provider.invalid/translate"),
                 Duration.ofSeconds(5),
-                true
+                true,
+                LibreTranslateTranslationService.MAX_INPUT_CODE_POINTS,
+                LibreTranslateTranslationService.MAX_TRANSLATED_CODE_POINTS,
+                8
         );
         List<CompletableFuture<String>> results = new ArrayList<>();
 
@@ -176,7 +179,10 @@ class LibreTranslateTranslationServiceTest {
                 provider.client,
                 URI.create("http://provider.invalid/translate"),
                 Duration.ofSeconds(5),
-                true
+                true,
+                LibreTranslateTranslationService.MAX_INPUT_CODE_POINTS,
+                LibreTranslateTranslationService.MAX_TRANSLATED_CODE_POINTS,
+                8
         );
         List<CompletableFuture<String>> firstBatch = new ArrayList<>();
         for (int index = 0; index < 8; index++) {
@@ -214,6 +220,33 @@ class LibreTranslateTranslationServiceTest {
 
         provider.completeNext("{\"translatedText\":\"four\"}");
         assertEquals("ก", first.get(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void defaultsToTwoConcurrentProviderRequests() throws Exception {
+        ControlledProvider provider = new ControlledProvider();
+        LibreTranslateTranslationService service = new LibreTranslateTranslationService(
+                provider.client,
+                URI.create("http://provider.invalid/translate"),
+                Duration.ofMillis(500),
+                true
+        );
+        String firstMessage = THAI_MESSAGE + " 1";
+        String secondMessage = THAI_MESSAGE + " 2";
+        String thirdMessage = THAI_MESSAGE + " 3";
+
+        CompletableFuture<String> first = service.translateToEnglish(firstMessage);
+        CompletableFuture<String> second = service.translateToEnglish(secondMessage);
+        CompletableFuture<String> third = service.translateToEnglish(thirdMessage);
+
+        try {
+            assertEquals(2, provider.requestCount.get());
+            assertEquals(thirdMessage, third.get(1, TimeUnit.SECONDS));
+        } finally {
+            provider.completeAll("{\"translatedText\":\"hello\"}");
+        }
+        assertEquals("hello", first.get(1, TimeUnit.SECONDS));
+        assertEquals("hello", second.get(1, TimeUnit.SECONDS));
     }
 
     @Test


### PR DESCRIPTION
## Summary

This adds optional Thai-to-English chat translation as a quality-of-life feature
for the current Fantasy Tennis community.

There are many active Thai-speaking players today. The goal is not to fix a broken
system; it is to make mixed Thai/English lobbies and matches easier and more fun for
everyone playing together.

Each player chooses independently:

```text
-translate on
-translate off
```

Translation is off by default, the preference is saved per player, and players who
do not opt in continue receiving the original message.

## Player behavior

- Covers lobby, room, and team chat.
- Keeps the sender's original message.
- Preserves room/team visibility and per-recipient message ordering.
- Prevents delayed translations from crossing leave/rejoin boundaries.
- Falls back to the original message on provider errors, timeouts, malformed
  responses, oversized input, or capacity limits.

## Self-hosted translation

The included Docker Compose deployment runs LibreTranslate inside the local stack.
No paid API, Google/DeepL account, or other cloud translation service is required.

Internet access is needed when Docker first pulls/builds the images and downloads the
checksum-pinned English/Thai model artifacts. At normal runtime:

- translation traffic stays inside the Compose network;
- the models are already baked into the provider image;
- mutable model-index/model downloads are disabled;
- emulator startup waits for a real Thai-to-English health probe.

### Starting after merge

From the repository's `docker` directory, the existing stack still starts normally
with translation disabled:

```sh
docker compose up -d --build
```

To enable the bundled Thai-to-English provider:

```sh
CHAT_TRANSLATION_ENABLED=true docker compose up -d --build
```

No API key or additional translation service is required.

## RAM impact

I measured the exact all-in-one Compose deployment on Linux after a fresh database
startup:

| Component | Idle | After translation load |
|-----------|------|------------------------|
| LibreTranslate | 763 MiB | 764 MiB (773 MiB observed peak) |
| Emulator (four JVMs) | 3.10 GiB | 3.16 GiB |
| MySQL | 469 MiB | 469 MiB |
| RabbitMQ | 144 MiB | 180 MiB |
| **Running-service total** | **about 4.45 GiB** | **about 4.54 GiB** |

The incremental translation-service cost was about **0.75 GiB**. Reserving **1 GiB**
for LibreTranslate is a reasonable operating allowance. For the exact all-in-one
Compose layout, an **8 GiB host is the practical minimum recommendation**, leaving
headroom for the OS, Docker, and transient JVM/database growth.

These are observed values rather than hard limits. Player count, traffic, JVM heap
behavior, Docker/kernel versions, and filesystem cache can change real usage.

Load scenario: 160 successful Thai-to-English requests at concurrency 8. The literal
probe returned:

```json
{"translatedText":"Anybody want to play double"}
```

## Concurrent performance

I also ran three rounds of 30 unique Thai messages at each concurrency level. Every
one of the 450 measured requests returned HTTP 200 with a non-empty translation:

| Concurrent requests | Throughput | Mean | p95 | Maximum |
|---------------------|------------|------|-----|---------|
| 1 | 17.75 req/s | 47.7 ms | 72.9 ms | 99.0 ms |
| 2 | 17.72 req/s | 100.9 ms | 157.9 ms | 217.4 ms |
| 4 | 10.72 req/s | 355.4 ms | 822.3 ms | 1010.7 ms |
| 8 | 10.69 req/s | 654.6 ms | 1266.6 ms | 1984.9 ms |
| 16 | 10.67 req/s | 1168.9 ms | 2107.4 ms | 2967.9 ms |

The included image is CPU-bound and effectively behaves like a one-worker translation
provider for unique messages. Concurrency 2 preserved the throughput of concurrency 1
while keeping the measured maximum below the default 450 ms timeout, so the included
default is now **2 concurrent provider requests**.

Completed translations are cached, duplicate in-flight requests are coalesced, and
requests above capacity fall back to original chat rather than blocking gameplay.
Operators using another or multi-worker provider can raise the configurable limit after
benchmarking their own host.

### Capacity with 100 connected players

Connected players are not the provider load unit. Inside one game or chat server
process, one Thai message sent to 100 opted-in recipients makes **one provider
request**, not 100: all recipients share the exact message's in-flight result, and
later repeats can use that process's 512-entry cache.

Game and chat are separate Java processes. Each owns its own concurrency limit and
cache while sharing the same LibreTranslate container. At the default limit they can
therefore admit up to four provider calls in total if both are busy simultaneously. A
constrained host expecting heavy activity on both can set
`CHAT_TRANSLATION_MAX_CONCURRENT_REQUESTS=1`, capping combined admission at two.

Provider capacity is instead governed by **unique untranslated messages per second**.
For intuition:

- 100 players averaging one unique Thai message every 10 seconds is 10 requests/s,
  below the measured 17.7 requests/s on this host.
- 100 players averaging one every 5 seconds is 20 requests/s, above this single
  instance's measured capacity.

Those are steady-state illustrations rather than guarantees; real traffic is bursty
and repeated messages are cheaper.

For the adversarial edge case, a deterministic test submits 100 unique Thai messages
at once through one server process. Exactly 2 enter the provider and the other 98
immediately retain their original text. The server does not queue seconds of stale chat
or block gameplay, and per-recipient delivery ordering remains intact.

This is intentionally best-effort QoL behavior under overload. A community that
requires every unique burst message to be translated should horizontally scale the
provider and benchmark that topology rather than simply raising concurrency on the
single CPU-bound instance.

## Deployment changes

- Pins Maven, MySQL, RabbitMQ, LibreTranslate, Supervisor, and language-model inputs.
- Builds English/Thai Argos and MiniSBD artifacts into the provider image with
  SHA-256 verification.
- Adds MySQL/RabbitMQ/provider readiness gates.
- Runs first-time application data import and atomic versioned SQL fixtures before
  starting the emulator.
- Makes translation timeout, input/output limits, and concurrency configurable.

## Verification

- `mvn clean install`
- 11/11 reactor modules successful
- 54 tests, 0 failures, 0 errors, 0 skipped
- Fresh `docker compose up -d --build`
- Import and fixture services exited 0
- MySQL, RabbitMQ, and LibreTranslate healthy
- Auth, chat, game, and relay programs RUNNING
- Real encrypted TCP lobby/room translation verified with two authenticated players
- `git diff --check`
- `docker compose config --quiet`
