### PR TITLE
Enable same-sex couples in the client

### DIFF
--- a/client-patches/patch-same-sex-couples.sh
+++ b/client-patches/patch-same-sex-couples.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: bash client-patches/patch-same-sex-couples.sh PATH/TO/FantaTennis.exe
+
+Removes the two client-side gender checks that reject same-sex proposals.
+The server already accepts and persists relationships without a gender check.
+
+The executable is validated at both patch locations before it is changed.
+A sibling .bak file is created before the first patch.
+EOF
+}
+
+if [[ $# -ne 1 || "$1" == "-h" || "$1" == "--help" ]]; then
+    usage
+    [[ $# -eq 1 ]] && exit 0
+    exit 2
+fi
+
+executable="$1"
+if [[ ! -f "$executable" ]]; then
+    echo "Client executable not found: $executable" >&2
+    exit 1
+fi
+
+if [[ -L "$executable" ]]; then
+    echo "Refusing to patch a symlinked executable: $executable" >&2
+    exit 1
+fi
+
+first_offset=$((0x1702e0))
+second_offset=$((0x172395))
+original_first="84d2746a"
+original_second="84d27477"
+patched="90909090"
+approved_original_sha="eebd71a1b19eca60101a195c49999d29600e6cdd6302c4a6001fb98043f91162"
+approved_patched_sha="ba3138048e92401eb19552b8f1a7be9eb5be8f2d84e35806fd856ecf392eb40e"
+
+read_bytes() {
+    od -An -tx1 -j "$2" -N 4 -- "$1" 2>/dev/null | tr -d ' \n'
+}
+
+executable_sha="$(sha256sum -- "$executable" | cut -d' ' -f1)"
+
+if [[ "$executable_sha" == "$approved_patched_sha" ]]; then
+    echo "Same-sex couple support is already enabled in $executable"
+    exit 0
+fi
+
+if [[ "$executable_sha" != "$approved_original_sha" ]]; then
+    echo "Unsupported FantaTennis.exe build; no changes were made. SHA-256: $executable_sha" >&2
+    exit 1
+fi
+
+first_bytes="$(read_bytes "$executable" "$first_offset")"
+second_bytes="$(read_bytes "$executable" "$second_offset")"
+
+if [[ "$first_bytes" != "$original_first" || "$second_bytes" != "$original_second" ]]; then
+    cat >&2 <<EOF
+Unsupported FantaTennis.exe build; no changes were made.
+Expected bytes: $original_first at 0x1702e0 and $original_second at 0x172395
+Found bytes:    ${first_bytes:-<unreadable>} at 0x1702e0 and ${second_bytes:-<unreadable>} at 0x172395
+EOF
+    exit 1
+fi
+
+backup="$executable.bak"
+if [[ -e "$backup" || -L "$backup" ]]; then
+    if [[ -L "$backup" || ! -f "$backup" || "$backup" -ef "$executable" ]]; then
+        echo "Existing backup is not an independent regular file; no changes were made: $backup" >&2
+        exit 1
+    fi
+    if ! cmp -s -- "$executable" "$backup"; then
+        echo "Existing backup does not match $executable; no changes were made: $backup" >&2
+        exit 1
+    fi
+fi
+
+if [[ ! -e "$backup" ]]; then
+    cp -p --update=none -- "$executable" "$backup"
+    if [[ ! -f "$backup" || -L "$backup" || "$backup" -ef "$executable" ]] ||
+       ! cmp -s -- "$executable" "$backup"; then
+        echo "Could not create an independent backup; no changes were made: $backup" >&2
+        exit 1
+    fi
+fi
+
+executable_dir="$(dirname -- "$executable")"
+executable_name="$(basename -- "$executable")"
+patched_copy="$(mktemp --tmpdir="$executable_dir" ".$executable_name.patch.XXXXXX")"
+trap 'rm -f -- "$patched_copy"' EXIT
+cp -p -- "$executable" "$patched_copy"
+
+printf '\x90\x90\x90\x90' | dd of="$patched_copy" bs=1 seek="$first_offset" conv=notrunc status=none
+printf '\x90\x90\x90\x90' | dd of="$patched_copy" bs=1 seek="$second_offset" conv=notrunc status=none
+
+if [[ "$(read_bytes "$patched_copy" "$first_offset")" != "$patched" ||
+      "$(read_bytes "$patched_copy" "$second_offset")" != "$patched" ||
+      "$(sha256sum -- "$patched_copy" | cut -d' ' -f1)" != "$approved_patched_sha" ]]; then
+    echo "Patch verification failed; restore from $backup" >&2
+    exit 1
+fi
+
+mv -f -- "$patched_copy" "$executable"
+trap - EXIT
+
+echo "Enabled same-sex couples in $executable"
+echo "Backup: $backup"

--- a/client-patches/test-patch-same-sex-couples.sh
+++ b/client-patches/test-patch-same-sex-couples.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+patcher="$script_dir/patch-same-sex-couples.sh"
+client_source="${FANTA_TENNIS_EXE:-$script_dir/../.jftse-client-linux/client/FantaTennis.exe}"
+fixture="$(mktemp)"
+matching_fixture="$(mktemp)"
+wrong_fixture="$(mktemp)"
+stale_fixture="$(mktemp)"
+hardlink_fixture="$(mktemp)"
+symlink_fixture="$(mktemp)"
+target_symlink_fixture="$(mktemp)"
+target_symlink_path="$target_symlink_fixture.link"
+fault_fixture="$(mktemp)"
+fault_dir="$(mktemp -d)"
+mixed_fixture="$(mktemp)"
+trap 'rm -f "$fixture" "$fixture.bak" "$matching_fixture" "$matching_fixture.bak" "$wrong_fixture" "$wrong_fixture.bak" "$stale_fixture" "$stale_fixture.bak" "$hardlink_fixture" "$hardlink_fixture.bak" "$symlink_fixture" "$symlink_fixture.bak" "$target_symlink_fixture" "$target_symlink_path" "$target_symlink_path.bak" "$fault_fixture" "$fault_fixture.bak" "$mixed_fixture" "$mixed_fixture.bak"; rm -rf "$fault_dir"' EXIT
+
+if [[ ! -f "$client_source" ]]; then
+    echo "Test client executable not found: $client_source" >&2
+    exit 1
+fi
+
+cp -- "$client_source" "$fixture"
+
+bash "$patcher" "$fixture"
+
+first_patch="$(od -An -tx1 -j $((0x1702e0)) -N 4 "$fixture" | tr -d ' \n')"
+second_patch="$(od -An -tx1 -j $((0x172395)) -N 4 "$fixture" | tr -d ' \n')"
+
+test "$first_patch" = "90909090"
+test "$second_patch" = "90909090"
+test -f "$fixture.bak"
+if ! cmp -s -- "$client_source" "$fixture.bak" || [[ "$fixture.bak" -ef "$fixture" ]]; then
+    echo "Expected a byte-identical independent backup" >&2
+    exit 1
+fi
+
+bash "$patcher" "$fixture"
+
+cp -- "$client_source" "$matching_fixture"
+cp -- "$client_source" "$matching_fixture.bak"
+matching_backup_before="$(sha256sum "$matching_fixture.bak" | cut -d' ' -f1)"
+
+if ! bash "$patcher" "$matching_fixture" >/dev/null 2>&1; then
+    echo "Expected a matching independent backup to be accepted" >&2
+    exit 1
+fi
+
+test "$(sha256sum "$matching_fixture" | cut -d' ' -f1)" = "ba3138048e92401eb19552b8f1a7be9eb5be8f2d84e35806fd856ecf392eb40e"
+test "$(sha256sum "$matching_fixture.bak" | cut -d' ' -f1)" = "$matching_backup_before"
+test ! "$matching_fixture.bak" -ef "$matching_fixture"
+
+if bash "$patcher" "$script_dir/does-not-exist.exe" >/dev/null 2>&1; then
+    echo "Expected a missing executable to fail" >&2
+    exit 1
+fi
+
+truncate -s $((0x172399)) "$wrong_fixture"
+printf '\x84\xd2\x74\x6a' | dd of="$wrong_fixture" bs=1 seek=$((0x1702e0)) conv=notrunc status=none
+printf '\x84\xd2\x74\x77' | dd of="$wrong_fixture" bs=1 seek=$((0x172395)) conv=notrunc status=none
+wrong_fixture_before="$(sha256sum "$wrong_fixture")"
+
+if bash "$patcher" "$wrong_fixture" >/dev/null 2>&1; then
+    echo "Expected a wrong-build executable to fail full-file validation" >&2
+    exit 1
+fi
+
+test "$(sha256sum "$wrong_fixture")" = "$wrong_fixture_before"
+test ! -e "$wrong_fixture.bak"
+
+cp -- "$client_source" "$stale_fixture"
+printf 'stale backup' >"$stale_fixture.bak"
+stale_fixture_before="$(sha256sum "$stale_fixture")"
+stale_backup_before="$(sha256sum "$stale_fixture.bak")"
+
+if bash "$patcher" "$stale_fixture" >/dev/null 2>&1; then
+    echo "Expected a mismatched existing backup to fail safely" >&2
+    exit 1
+fi
+
+test "$(sha256sum "$stale_fixture")" = "$stale_fixture_before"
+test "$(sha256sum "$stale_fixture.bak")" = "$stale_backup_before"
+
+cp -- "$client_source" "$hardlink_fixture"
+ln -- "$hardlink_fixture" "$hardlink_fixture.bak"
+hardlink_fixture_before="$(sha256sum "$hardlink_fixture" | cut -d' ' -f1)"
+
+if bash "$patcher" "$hardlink_fixture" >/dev/null 2>&1; then
+    echo "Expected a hardlinked backup alias to fail safely" >&2
+    exit 1
+fi
+
+test "$(sha256sum "$hardlink_fixture" | cut -d' ' -f1)" = "$hardlink_fixture_before"
+test "$(sha256sum "$hardlink_fixture.bak" | cut -d' ' -f1)" = "$hardlink_fixture_before"
+
+cp -- "$client_source" "$symlink_fixture"
+ln -s -- "$symlink_fixture" "$symlink_fixture.bak"
+symlink_fixture_before="$(sha256sum "$symlink_fixture" | cut -d' ' -f1)"
+
+if bash "$patcher" "$symlink_fixture" >/dev/null 2>&1; then
+    echo "Expected a symlinked backup alias to fail safely" >&2
+    exit 1
+fi
+
+test "$(sha256sum "$symlink_fixture" | cut -d' ' -f1)" = "$symlink_fixture_before"
+test "$(sha256sum "$symlink_fixture.bak" | cut -d' ' -f1)" = "$symlink_fixture_before"
+
+cp -- "$client_source" "$target_symlink_fixture"
+ln -s -- "$target_symlink_fixture" "$target_symlink_path"
+target_symlink_before="$(sha256sum "$target_symlink_fixture" | cut -d' ' -f1)"
+
+if bash "$patcher" "$target_symlink_path" >/dev/null 2>&1; then
+    echo "Expected a symlinked executable target to fail safely" >&2
+    exit 1
+fi
+
+test -L "$target_symlink_path"
+test "$(sha256sum "$target_symlink_fixture" | cut -d' ' -f1)" = "$target_symlink_before"
+test ! -e "$target_symlink_path.bak"
+
+cp -- "$client_source" "$fault_fixture"
+fault_fixture_before="$(sha256sum "$fault_fixture" | cut -d' ' -f1)"
+real_dd="$(command -v dd)"
+cat >"$fault_dir/dd" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+count=0
+[[ -f "$DD_COUNTER" ]] && read -r count <"$DD_COUNTER"
+count=$((count + 1))
+printf '%s\n' "$count" >"$DD_COUNTER"
+if [[ $count -eq 2 ]]; then
+    exit 1
+fi
+exec "$REAL_DD" "$@"
+EOF
+chmod +x "$fault_dir/dd"
+
+if PATH="$fault_dir:$PATH" DD_COUNTER="$fault_dir/count" REAL_DD="$real_dd" \
+    bash "$patcher" "$fault_fixture" >/dev/null 2>&1; then
+    echo "Expected a second-write failure to leave the executable unchanged" >&2
+    exit 1
+fi
+
+if [[ "$(sha256sum "$fault_fixture" | cut -d' ' -f1)" != "$fault_fixture_before" ]]; then
+    echo "A failed patch left the executable partially modified" >&2
+    exit 1
+fi
+test "$(sha256sum "$fault_fixture.bak" | cut -d' ' -f1)" = "$fault_fixture_before"
+fault_temp_count="$(find "$(dirname -- "$fault_fixture")" -maxdepth 1 \
+    -name ".$(basename -- "$fault_fixture").patch.*" -print | wc -l)"
+if [[ "$fault_temp_count" -ne 0 ]]; then
+    echo "A failed patch left a temporary executable copy" >&2
+    exit 1
+fi
+
+truncate -s $((0x172399)) "$mixed_fixture"
+printf '\x84\xd2\x74\x6a' | dd of="$mixed_fixture" bs=1 seek=$((0x1702e0)) conv=notrunc status=none
+mixed_fixture_before="$(sha256sum "$mixed_fixture")"
+
+if bash "$patcher" "$mixed_fixture" >/dev/null 2>&1; then
+    echo "Expected a mixed-signature executable to fail safely" >&2
+    exit 1
+fi
+
+test "$(sha256sum "$mixed_fixture")" = "$mixed_fixture_before"
+test ! -e "$mixed_fixture.bak"
+
+echo "same-sex couple client patch tests passed"


### PR DESCRIPTION
Adds a small client patch that removes the two legacy gender checks blocking same-sex couple proposals. The server already supports these relationships; only the client prevented the request.

The patch validates the exact executable, keeps an independent backup, applies atomically, and includes regression coverage for supported and fail-closed cases.