### PR TITLE
Let players join ongoing matches as spectators

### DIFF
--- a/game-server/src/main/java/com/jftse/emulator/server/core/handler/lobby/room/RoomJoinRequestPacketHandler.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/handler/lobby/room/RoomJoinRequestPacketHandler.java
@@ -6,13 +6,17 @@ import com.jftse.emulator.server.core.client.FTPlayer;
 import com.jftse.emulator.server.core.constants.MiscConstants;
 import com.jftse.emulator.server.core.constants.RoomPositionState;
 import com.jftse.emulator.server.core.constants.RoomStatus;
+import com.jftse.emulator.server.core.life.room.GameSession;
 import com.jftse.emulator.server.core.life.room.Room;
 import com.jftse.emulator.server.core.life.room.RoomPlayer;
 import com.jftse.emulator.server.core.manager.GameManager;
 import com.jftse.emulator.server.core.manager.ServiceManager;
+import com.jftse.emulator.server.core.matchplay.GameSessionManager;
 import com.jftse.emulator.server.core.packets.lobby.room.*;
+import com.jftse.emulator.server.core.packets.matchplay.S2CGameNetworkSettingsPacket;
 import com.jftse.emulator.server.net.FTClient;
 import com.jftse.emulator.server.net.FTConnection;
+import com.jftse.entities.database.model.gameserver.GameServer;
 import com.jftse.entities.database.model.messenger.Friend;
 import com.jftse.entities.database.model.player.*;
 import com.jftse.server.core.handler.PacketHandler;
@@ -23,9 +27,11 @@ import com.jftse.server.core.service.SocialService;
 import com.jftse.server.core.shared.packets.lobby.room.CMSGRoomJoin;
 import com.jftse.server.core.shared.packets.lobby.room.SMSGRoomCloseSlot;
 import com.jftse.server.core.shared.packets.lobby.room.SMSGRoomJoin;
+import com.jftse.server.core.shared.packets.matchplay.SMSGUnsetHost;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 
 @PacketId(CMSGRoomJoin.PACKET_ID)
@@ -77,7 +83,8 @@ public class RoomJoinRequestPacketHandler implements PacketHandler<FTConnection,
         final boolean isTownSquare = room.getRoomType() == 1 && room.getMode() == 2;
         final ConcurrentLinkedDeque<RoomPlayer> roomPlayerList = room.getRoomPlayerList();
 
-        if (room.getStatus() != RoomStatus.NotRunning) {
+        boolean joiningRunningMatch = room.getStatus() == RoomStatus.Running;
+        if (room.getStatus() != RoomStatus.NotRunning && !joiningRunningMatch) {
             SMSGRoomJoin roomJoinAnswerPacket = SMSGRoomJoin.builder()
                     .result((char) -1)
                     .roomType((byte) 0)
@@ -90,6 +97,28 @@ public class RoomJoinRequestPacketHandler implements PacketHandler<FTConnection,
 
             GameManager.getInstance().updateRoomForAllClientsInMultiplayer(ftClient.getConnection(), room);
             return;
+        }
+
+        GameSession joiningGameSession = null;
+        int joiningGameSessionId = 0;
+        if (joiningRunningMatch) {
+            FTClient matchClient = GameManager.getInstance().getClientsInRoom(room.getRoomId()).stream()
+                    .filter(client -> client.getActiveGameSession() != null)
+                    .findFirst()
+                    .orElse(null);
+            if (matchClient == null) {
+                SMSGRoomJoin roomJoinAnswerPacket = SMSGRoomJoin.builder()
+                        .result((char) -1)
+                        .roomType((byte) 0)
+                        .mode((byte) 0)
+                        .mapId((byte) 0)
+                        .build();
+                connection.sendTCP(roomJoinAnswerPacket);
+                resetIsJoiningOrLeavingRoom(ftClient);
+                return;
+            }
+            joiningGameSession = matchClient.getActiveGameSession();
+            joiningGameSessionId = matchClient.getGameSessionId();
         }
 
         FTPlayer activePlayer = ftClient.getPlayer();
@@ -219,8 +248,14 @@ public class RoomJoinRequestPacketHandler implements PacketHandler<FTConnection,
 
         int newPosition = -1;
         if (!isTownSquare) {
-            Optional<Short> num = room.getPositions().stream().filter(x -> x == RoomPositionState.Free).findFirst();
-            newPosition = useGmSlot ? 9 : num.map(pos -> room.getPositions().indexOf(pos)).orElse(-1);
+            if (joiningRunningMatch) {
+                newPosition = useGmSlot ? 9 : findAvailableSpectatorPosition(room).orElse(-1);
+            } else {
+                Optional<Short> position = room.getPositions().stream()
+                        .filter(state -> state == RoomPositionState.Free)
+                        .findFirst();
+                newPosition = useGmSlot ? 9 : position.map(room.getPositions()::indexOf).orElse(-1);
+            }
         } else {
             List<Short> positions = roomPlayerList.stream().map(RoomPlayer::getPosition).toList();
             newPosition = (short) IntStream.range(0, room.getPlayers())
@@ -269,9 +304,78 @@ public class RoomJoinRequestPacketHandler implements PacketHandler<FTConnection,
 
         room.getRoomPlayerList().add(roomPlayer);
 
+        if (joiningRunningMatch
+                && !attachToRunningSession(room, ftClient, joiningGameSessionId, joiningGameSession)) {
+            room.getRoomPlayerList().remove(roomPlayer);
+            room.getPositions().set(newPosition, RoomPositionState.Free);
+            ftClient.setActiveRoom(null);
+            ftClient.setInLobby(true);
+            SMSGRoomJoin failedJoin = SMSGRoomJoin.builder()
+                    .result((char) -1)
+                    .roomType((byte) 0)
+                    .mode((byte) 0)
+                    .mapId((byte) 0)
+                    .build();
+            connection.sendTCP(failedJoin);
+            resetIsJoiningOrLeavingRoom(ftClient);
+            return;
+        }
+
         handleRoomUponJoin(connection, room, false);
 
+        if (joiningRunningMatch) {
+            sendRunningMatchConnectionSettings(connection, room, joiningGameSessionId);
+        }
+
         ftClient.getIsJoiningOrLeavingRoom().set(false);
+    }
+
+    private static OptionalInt findAvailableSpectatorPosition(Room room) {
+        return IntStream.rangeClosed(5, 8)
+                .filter(position -> room.getPositions().get(position) == RoomPositionState.Free)
+                .findFirst();
+    }
+
+    private static boolean attachToRunningSession(
+            Room room,
+            FTClient client,
+            int gameSessionId,
+            GameSession capturedSession) {
+        AtomicBoolean attached = new AtomicBoolean(false);
+        GameSessionManager.getInstance().getGameSessionList().computeIfPresent(gameSessionId, (id, currentSession) -> {
+            if (currentSession == capturedSession && room.getStatus() == RoomStatus.Running) {
+                currentSession.getClients().add(client);
+                client.setActiveGameSession(gameSessionId);
+                attached.set(true);
+            }
+            return currentSession;
+        });
+        return attached.get();
+    }
+
+    private void sendRunningMatchConnectionSettings(
+            FTConnection connection,
+            Room room,
+            int gameSessionId) {
+        GameServer relayServer = ServiceManager.getInstance().getAuthenticationService()
+                .getGameServerByPort(GameManager.getInstance().getServerConfService().get("RelayPort", Integer.class));
+        FTClient joiningClient = connection.getClient();
+        List<FTClient> relayClients = new ArrayList<>();
+        relayClients.add(joiningClient);
+        GameManager.getInstance().getClientsInRoom(room.getRoomId()).stream()
+                .filter(client -> client != joiningClient)
+                .filter(client -> client.getRoomPlayer() != null && client.getRoomPlayer().getPosition() < 4)
+                .sorted(Comparator.comparingInt(client -> client.getRoomPlayer().getPosition()))
+                .limit(3)
+                .forEach(relayClients::add);
+        SMSGUnsetHost unsetHost = SMSGUnsetHost.builder().result((byte) 0).build();
+        S2CGameNetworkSettingsPacket settings = new S2CGameNetworkSettingsPacket(
+                relayServer.getHost(),
+                relayServer.getPort(),
+                gameSessionId,
+                room,
+                relayClients);
+        connection.sendTCP(unsetHost, settings);
     }
 
     private void handleRoomUponJoin(final FTConnection connection, Room room, boolean existingRoom) {

--- a/game-server/src/main/java/com/jftse/emulator/server/core/handler/matchplay/ConnectedToRelayHandler.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/handler/matchplay/ConnectedToRelayHandler.java
@@ -1,6 +1,7 @@
 package com.jftse.emulator.server.core.handler.matchplay;
 
 import com.jftse.emulator.server.core.constants.RoomStatus;
+import com.jftse.emulator.server.core.life.room.GameSession;
 import com.jftse.emulator.server.core.life.room.Room;
 import com.jftse.emulator.server.core.life.room.RoomPlayer;
 import com.jftse.emulator.server.net.FTClient;
@@ -22,12 +23,27 @@ public class ConnectedToRelayHandler implements PacketHandler<FTConnection, CMSG
         }
 
         RoomPlayer roomPlayer = ftClient.getRoomPlayer();
+        Room room = ftClient.getActiveRoom();
+        if (room != null
+                && room.getStatus() == RoomStatus.Running
+                && roomPlayer != null
+                && roomPlayer.getPosition() > 3) {
+            GameSession gameSession = ftClient.getActiveGameSession();
+            if (gameSession == null) {
+                SMSGConnectedToRelay answer = SMSGConnectedToRelay.builder().result((byte) 1).build();
+                connection.sendTCP(answer);
+                return;
+            }
+            roomPlayer.getConnectedToRelay().compareAndSet(false, true);
+            connection.sendTCP(LateSpectatorBootstrap.packetsFor(gameSession, room));
+            return;
+        }
+
         if (roomPlayer == null || !roomPlayer.getConnectedToRelay().compareAndSet(false, true)) {
             SMSGConnectedToRelay answer = SMSGConnectedToRelay.builder().result((byte) 1).build();
             connection.sendTCP(answer);
 
-            Room room = ftClient.getActiveRoom();
-            if (room != null) {
+            if (room != null && room.getStatus() != RoomStatus.Running) {
                 synchronized (room) {
                     room.setStatus(RoomStatus.RelayConnectionFailed);
                 }
@@ -35,7 +51,6 @@ public class ConnectedToRelayHandler implements PacketHandler<FTConnection, CMSG
             return;
         }
 
-        Room room = ftClient.getActiveRoom();
         ConcurrentLinkedDeque<RoomPlayer> roomPlayerList = room.getRoomPlayerList();
         if (roomPlayerList.stream().allMatch(rp -> rp.getConnectedToRelay().get())) {
             room.setStatus(RoomStatus.RelayConnectionSuccess);

--- a/game-server/src/main/java/com/jftse/emulator/server/core/handler/matchplay/LateSpectatorBootstrap.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/handler/matchplay/LateSpectatorBootstrap.java
@@ -1,0 +1,128 @@
+package com.jftse.emulator.server.core.handler.matchplay;
+
+import com.jftse.emulator.server.core.constants.ServeType;
+import com.jftse.emulator.server.core.life.room.GameSession;
+import com.jftse.emulator.server.core.life.room.PlayerPositionInfo;
+import com.jftse.emulator.server.core.life.room.Room;
+import com.jftse.emulator.server.core.life.room.RoomPlayer;
+import com.jftse.emulator.server.core.life.room.ServeInfo;
+import com.jftse.emulator.server.core.matchplay.MatchplayGame;
+import com.jftse.emulator.server.core.matchplay.game.MatchplayBasicGame;
+import com.jftse.emulator.server.core.matchplay.game.MatchplayBattleGame;
+import com.jftse.emulator.server.core.matchplay.game.MatchplayGuardianGame;
+import com.jftse.emulator.server.core.packets.lobby.room.S2CRoomSetBossGuardiansStats;
+import com.jftse.emulator.server.core.packets.lobby.room.S2CRoomSetGuardianStats;
+import com.jftse.emulator.server.core.packets.lobby.room.S2CRoomSetGuardians;
+import com.jftse.emulator.server.core.packets.matchplay.S2CGameDisplayPlayerStatsPacket;
+import com.jftse.emulator.server.core.packets.matchplay.S2CGameSetNameColorAndRemoveBlackBar;
+import com.jftse.emulator.server.core.packets.matchplay.S2CMatchplaySetPlayerPosition;
+import com.jftse.emulator.server.core.packets.matchplay.S2CMatchplaySpawnBossBattle;
+import com.jftse.emulator.server.core.packets.matchplay.S2CMatchplayTriggerGuardianServe;
+import com.jftse.emulator.server.core.packets.matchplay.S2CMatchplayTriggerServe;
+import com.jftse.emulator.server.core.utils.ServingPositionGenerator;
+import com.jftse.entities.database.model.battle.GuardianBase;
+import com.jftse.server.core.protocol.IPacket;
+import com.jftse.server.core.protocol.Packet;
+import com.jftse.server.core.protocol.PacketOperations;
+import com.jftse.server.core.shared.packets.matchplay.SMSGStartGame;
+
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+final class LateSpectatorBootstrap {
+    private LateSpectatorBootstrap() {
+    }
+
+    static IPacket[] packetsFor(GameSession session, Room room) {
+        MatchplayGame game = session.getMatchplayGame();
+        List<IPacket> packets = new ArrayList<>();
+        if (game instanceof MatchplayGuardianGame guardianGame) {
+            addGuardians(packets, guardianGame);
+        }
+        packets.add(SMSGStartGame.builder().result((char) 0).build());
+        packets.add(new S2CGameDisplayPlayerStatsPacket(new ArrayList<>(room.getRoomPlayerList()), room.getMode()));
+        packets.add(new S2CGameSetNameColorAndRemoveBlackBar(room));
+
+        if (game instanceof MatchplayBasicGame basicGame) {
+            packets.add(new Packet(PacketOperations.S2CGameRemoveBlackBars));
+            packets.add(new S2CMatchplayTriggerServe(serveInfo(room, basicGame)));
+        } else if (game instanceof MatchplayBattleGame battleGame) {
+            packets.add(new S2CMatchplaySetPlayerPosition(positionInfo(room, battleGame.getPlayerLocationsOnMap())));
+            packets.add(guardianServe(battleGame.getLastGuardianServeSide().get()));
+        } else if (game instanceof MatchplayGuardianGame guardianGame) {
+            packets.add(guardianServe(guardianGame.getLastGuardianServeSide().get()));
+        }
+        return packets.toArray(IPacket[]::new);
+    }
+
+    private static List<ServeInfo> serveInfo(Room room, MatchplayBasicGame game) {
+        List<ServeInfo> result = new ArrayList<>();
+        for (RoomPlayer player : activePlayers(room)) {
+            ServeInfo info = new ServeInfo();
+            info.setPlayerPosition(player.getPosition());
+            info.setPlayerStartLocation(game.getPlayerLocationsOnMap().get(player.getPosition()));
+            info.setServeType(player == game.getServePlayer().get()
+                    ? ServeType.ServeBall
+                    : player == game.getReceiverPlayer().get() ? ServeType.ReceiveBall : ServeType.None);
+            result.add(info);
+        }
+        return result;
+    }
+
+    private static List<PlayerPositionInfo> positionInfo(Room room, List<Point> locations) {
+        List<PlayerPositionInfo> result = new ArrayList<>();
+        for (RoomPlayer player : activePlayers(room)) {
+            PlayerPositionInfo info = new PlayerPositionInfo();
+            info.setPlayerPosition(player.getPosition());
+            info.setPlayerStartLocation(locations.get(player.getPosition()));
+            result.add(info);
+        }
+        return result;
+    }
+
+    private static List<RoomPlayer> activePlayers(Room room) {
+        return room.getRoomPlayerList().stream()
+                .filter(player -> player.getPosition() < 4)
+                .sorted(Comparator.comparingInt(RoomPlayer::getPosition))
+                .toList();
+    }
+
+    private static S2CMatchplayTriggerGuardianServe guardianServe(int side) {
+        int x = ServingPositionGenerator.randomServingPositionXOffset();
+        int y = ServingPositionGenerator.randomServingPositionYOffset(x);
+        return new S2CMatchplayTriggerGuardianServe((byte) side, (byte) x, (byte) y);
+    }
+
+    private static void addGuardians(List<IPacket> packets, MatchplayGuardianGame game) {
+        List<GuardianBase> guardians = game.getGuardianBattleStates().stream()
+                .sorted(Comparator.comparingInt(state -> state.getPosition()))
+                .map(state -> game.getGuardiansInStage().stream()
+                        .<GuardianBase>map(mapping -> state.isBoss()
+                                ? mapping.getBossGuardian()
+                                : mapping.getGuardian())
+                        .filter(java.util.Objects::nonNull)
+                        .filter(guardian -> guardian.getId() == state.getId())
+                        .findFirst()
+                        .orElseGet(() -> game.getGuardiansInBossStage().stream()
+                                .<GuardianBase>map(mapping -> state.isBoss()
+                                        ? mapping.getBossGuardian()
+                                        : mapping.getGuardian())
+                                .filter(java.util.Objects::nonNull)
+                                .filter(guardian -> guardian.getId() == state.getId())
+                                .findFirst()
+                                .orElse(null)))
+                .toList();
+        GuardianBase[] slots = Arrays.copyOf(guardians.toArray(GuardianBase[]::new), 3);
+        List<GuardianBase> padded = Arrays.asList(slots);
+        if (game.getBossBattleActive().get()) {
+            packets.add(new S2CMatchplaySpawnBossBattle(slots[0], slots[1], slots[2]));
+            packets.add(new S2CRoomSetBossGuardiansStats(game.getGuardianBattleStates(), padded));
+        } else {
+            packets.add(new S2CRoomSetGuardians(slots[0], slots[1], slots[2]));
+            packets.add(new S2CRoomSetGuardianStats(game.getGuardianBattleStates(), padded));
+        }
+    }
+}

--- a/game-server/src/main/java/com/jftse/emulator/server/net/TCPChannelHandler.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/net/TCPChannelHandler.java
@@ -112,16 +112,17 @@ public class TCPChannelHandler extends TCPHandlerV2<FTConnection> {
 
             Room currentClientRoom = client.getActiveRoom();
             if (currentClientRoom != null) {
-                if (player != null && currentClientRoom.getStatus() == RoomStatus.Running) {
+                RoomPlayer roomPlayer = client.getRoomPlayer();
+                boolean isActivePlayer = roomPlayer != null && roomPlayer.getPosition() < 4;
+                if (player != null && isActivePlayer && currentClientRoom.getStatus() == RoomStatus.Running) {
                     PlayerStatistic playerStatistic = ServiceManager.getInstance().getPlayerStatisticService().findPlayerStatisticById(player.getPlayerStatisticId());
                     playerStatistic.setNumberOfDisconnects(playerStatistic.getNumberOfDisconnects() + 1);
                     ServiceManager.getInstance().getPlayerStatisticService().save(playerStatistic);
                 }
 
-                RoomPlayer roomPlayer = client.getRoomPlayer();
                 if (roomPlayer != null) {
                     roomPlayer.getConnectedToRelay().compareAndSet(true, false);
-                    notifyClients = roomPlayer.getPosition() < 4;
+                    notifyClients = isActivePlayer;
                     if (notifyClients) {
                         synchronized (currentClientRoom) {
                             currentClientRoom.setStatus(RoomStatus.NotRunning);
@@ -138,14 +139,15 @@ public class TCPChannelHandler extends TCPHandlerV2<FTConnection> {
                             }
                         });
                         GameSessionManager.getInstance().getGameSessionList().remove(client.getGameSessionId(), gameSession);
+
+                        MatchplayGame game = gameSession.getMatchplayGame();
+                        game.getScheduledFutures().forEach(sf -> sf.cancel(false));
+                        game.getScheduledFutures().clear();
+
+                        GameManager.getInstance().getMatchRallyStatsConsumer().clearSession(client.getGameSessionId());
                     }
                 }
-                MatchplayGame game = gameSession.getMatchplayGame();
-                game.getScheduledFutures().forEach(sf -> sf.cancel(false));
-                game.getScheduledFutures().clear();
-
-                GameManager.getInstance().getMatchRallyStatsConsumer().clearSession(client.getGameSessionId());
-
+            } else {
                 client.setActiveGameSession(null);
             }
         }


### PR DESCRIPTION
## Why

Players currently cannot enter a room while its match is running. If friends are already playing, the player has to wait outside until the match ends before they can join them.

This change improves that experience: a player can enter the ongoing match immediately as a spectator, watch the current game, and already be in the room for the next round.

## Player experience

### Before

1. Your friends start a match before you reach their room.
2. You try to join, but the running room cannot accept you.
3. You have to wait outside and keep checking until the match finishes.
4. Only then can you enter the room and play with them.

### After

1. Your friends are already in a match, but you can still join their room.
2. You enter the current match automatically as a spectator.
3. You can watch what your friends are playing instead of waiting outside.
4. When the match finishes, you are already with the group and can join the next round normally.

The player does not spawn into the round already in progress. They observe that round, then participate from the next match onward. This keeps the ongoing game fair while making it much easier to join friends.

## What this solves

- A player can join a room whose match is already running.
- The late joiner uses a spectator slot instead of taking an active-player slot.
- The spectator receives enough of the current match state to see what is happening.
- A spectator leaving does not stop the match for the active players.

## How it works

A late spectator join is treated as attaching an observer to the existing game session, not as starting another match:

1. Running rooms accept late joins only in spectator positions 5 through 8.
2. The spectator is attached to the current `GameSession`; if that session ends during the join, admission is rolled back safely.
3. Relay settings identify the joining spectator correctly.
4. After connecting to the relay, the spectator receives the current display, player-position, serve, and Guardian state required for the active game mode.
5. Disconnect handling distinguishes spectators from active players, preserving the existing active-player teardown behavior.

The mode-specific packet composition is kept in the package-private `LateSpectatorBootstrap` helper so the admission, relay, and disconnect handlers remain focused on their own responsibilities.

## Safety

- Active-player startup, scoring, and gameplay are unchanged.
- Active-player slots cannot be taken by late spectators.
- A stale or missing session fails the join safely.
- Duplicate spectator relay acknowledgements remain recoverable.
- Spectator disconnects cannot terminate the running match.

## Verification

Temporary QA harnesses exercised:

- the first available spectator slot and full spectator slots;
- session shutdown during admission and rollback;
- Basic, Battle, Guardian, and boss-Guardian bootstrap ordering;
- duplicate relay acknowledgement;
- spectator versus active-player disconnect behavior.

The temporary harnesses were removed before publishing. The rebased branch passes:

```bash
mvn -Dmaven.gitcommitid.skip=true -pl game-server -am clean verify
```

Result: **7 tests, 0 failures, 0 errors, 0 skipped**, with all affected reactor modules building successfully.