### PR TITLE
Decline proposals when replying

### DIFF
--- a/chat-server/src/main/java/com/jftse/emulator/server/core/handler/messenger/SendMessageRequestHandler.java
+++ b/chat-server/src/main/java/com/jftse/emulator/server/core/handler/messenger/SendMessageRequestHandler.java
@@ -12,6 +12,7 @@ import com.jftse.server.core.handler.PacketHandler;
 import com.jftse.server.core.handler.PacketId;
 import com.jftse.server.core.service.MessageService;
 import com.jftse.server.core.service.PlayerService;
+import com.jftse.server.core.service.ProposalService;
 import com.jftse.server.core.shared.packets.messenger.CMSGSendMessage;
 import com.jftse.server.core.shared.rabbit.messages.PacketMessage;
 
@@ -21,12 +22,14 @@ import java.util.List;
 public class SendMessageRequestHandler implements PacketHandler<FTConnection, CMSGSendMessage> {
     private final PlayerService playerService;
     private final MessageService messageService;
+    private final ProposalService proposalService;
 
     private final RProducerService rProducerService;
 
     public SendMessageRequestHandler() {
         playerService = ServiceManager.getInstance().getPlayerService();
         messageService = ServiceManager.getInstance().getMessageService();
+        proposalService = ServiceManager.getInstance().getProposalService();
         rProducerService = RProducerService.getInstance();
     }
 
@@ -51,6 +54,7 @@ public class SendMessageRequestHandler implements PacketHandler<FTConnection, CM
             message.setMessage(packet.getMessage());
             message.setSeen(false);
             messageService.save(message);
+            proposalService.deleteBySenderAndReceiver(receiver, player.getPlayerRef());
 
             S2CReceivedMessageNotificationPacket s2CReceivedMessageNotificationPacket = new S2CReceivedMessageNotificationPacket(message, player.getName());
 

--- a/entities/src/main/java/com/jftse/entities/database/repository/messenger/ProposalRepository.java
+++ b/entities/src/main/java/com/jftse/entities/database/repository/messenger/ProposalRepository.java
@@ -3,7 +3,9 @@ package com.jftse.entities.database.repository.messenger;
 import com.jftse.entities.database.model.messenger.Proposal;
 import com.jftse.entities.database.model.player.Player;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,4 +23,8 @@ public interface ProposalRepository extends JpaRepository<Proposal, Long> {
 
     long deleteBySender(Player sender);
     long deleteByReceiver(Player receiver);
+
+    @Modifying
+    @Query("DELETE FROM Proposal p WHERE p.sender = :sender AND p.receiver = :receiver")
+    int deleteBySenderAndReceiver(@Param("sender") Player sender, @Param("receiver") Player receiver);
 }

--- a/game-server/src/main/java/com/jftse/emulator/server/core/handler/messenger/SendMessageRequestHandler.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/handler/messenger/SendMessageRequestHandler.java
@@ -12,6 +12,7 @@ import com.jftse.server.core.handler.PacketHandler;
 import com.jftse.server.core.handler.PacketId;
 import com.jftse.server.core.service.MessageService;
 import com.jftse.server.core.service.PlayerService;
+import com.jftse.server.core.service.ProposalService;
 import com.jftse.server.core.shared.packets.messenger.CMSGSendMessage;
 import com.jftse.server.core.shared.rabbit.messages.PacketMessage;
 
@@ -21,12 +22,14 @@ import java.util.List;
 public class SendMessageRequestHandler implements PacketHandler<FTConnection, CMSGSendMessage> {
     private final PlayerService playerService;
     private final MessageService messageService;
+    private final ProposalService proposalService;
 
     private final RProducerService rProducerService;
 
     public SendMessageRequestHandler() {
         playerService = ServiceManager.getInstance().getPlayerService();
         messageService = ServiceManager.getInstance().getMessageService();
+        proposalService = ServiceManager.getInstance().getProposalService();
         rProducerService = RProducerService.getInstance();
     }
 
@@ -51,6 +54,7 @@ public class SendMessageRequestHandler implements PacketHandler<FTConnection, CM
             message.setMessage(packet.getMessage());
             message.setSeen(false);
             messageService.save(message);
+            proposalService.deleteBySenderAndReceiver(receiver, player.getPlayerRef());
 
             S2CReceivedMessageNotificationPacket s2CReceivedMessageNotificationPacket = new S2CReceivedMessageNotificationPacket(message, player.getName());
 

--- a/server-core/src/main/java/com/jftse/server/core/service/ProposalService.java
+++ b/server-core/src/main/java/com/jftse/server/core/service/ProposalService.java
@@ -23,4 +23,6 @@ public interface ProposalService {
     long deleteBySender(Player sender);
 
     long deleteByReceiver(Player receiver);
+
+    int deleteBySenderAndReceiver(Player sender, Player receiver);
 }

--- a/server-core/src/main/java/com/jftse/server/core/service/impl/ProposalServiceImpl.java
+++ b/server-core/src/main/java/com/jftse/server/core/service/impl/ProposalServiceImpl.java
@@ -69,4 +69,10 @@ public class ProposalServiceImpl implements ProposalService {
     public long deleteByReceiver(Player receiver) {
         return proposalRepository.deleteByReceiver(receiver);
     }
+
+    @Override
+    @Transactional
+    public int deleteBySenderAndReceiver(Player sender, Player receiver) {
+        return proposalRepository.deleteBySenderAndReceiver(sender, receiver);
+    }
 }


### PR DESCRIPTION
## Why

The client handles Reply as a normal messenger response rather than an explicit proposal answer. The server therefore delivered the reply without resolving the pending proposal.

## Current in-game behaviour

When a player replies to a received proposal, the message reaches the proposal sender, but the proposal remains pending and its notification continues to appear. The player must resolve it separately.

## Behaviour after this change

Replying still sends the message normally. Once the message is saved, any pending proposal from that recipient to the replying player is declined and removed, so it no longer appears in the proposal list.

Explicit Accept and Decline actions continue to behave as before.

## What changed

- Added a targeted bulk delete for proposals identified by sender and receiver.
- Exposed the operation through the existing proposal service layer and transaction boundary.
- Applied it after successful message persistence in both the game-server and chat-server reply paths.

This keeps the two server paths consistent and resolves the proposal with a single database operation.