### PR TITLE
prevent empty messenger lists for large histories

### DIFF
--- a/chat-server/src/main/java/com/jftse/emulator/server/core/packets/messenger/S2CMessageListAnswerPacket.java
+++ b/chat-server/src/main/java/com/jftse/emulator/server/core/packets/messenger/S2CMessageListAnswerPacket.java
@@ -14,7 +14,17 @@ public class S2CMessageListAnswerPacket extends Packet {
 
         this.write(listType);
 
-        int size = Math.min(messageList.size(), 128);
+        int size = 0;
+        int packetSize = 10; // 8-byte header, list type and count
+        while (size < messageList.size() && size < Byte.MAX_VALUE) {
+            AbstractMessage message = messageList.get(size);
+            String playerName = (listType % 2) == 0 ? message.getSender().getName() : message.getReceiver().getName();
+            int entrySize = 22 + 2 * (playerName.length() + message.getMessage().length());
+            if (packetSize + entrySize > 16 * 1024)
+                break;
+            packetSize += entrySize;
+            size++;
+        }
         messageList = messageList.subList(0, size);
         this.write((byte) size);
         for (AbstractMessage am : messageList) {

--- a/game-server/src/main/java/com/jftse/emulator/server/core/packets/messenger/S2CMessageListAnswerPacket.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/packets/messenger/S2CMessageListAnswerPacket.java
@@ -14,7 +14,17 @@ public class S2CMessageListAnswerPacket extends Packet {
 
         this.write(listType);
 
-        int size = Math.min(messageList.size(), 128);
+        int size = 0;
+        int packetSize = 10; // 8-byte header, list type and count
+        while (size < messageList.size() && size < Byte.MAX_VALUE) {
+            AbstractMessage message = messageList.get(size);
+            String playerName = (listType % 2) == 0 ? message.getSender().getName() : message.getReceiver().getName();
+            int entrySize = 22 + 2 * (playerName.length() + message.getMessage().length());
+            if (packetSize + entrySize > 16 * 1024)
+                break;
+            packetSize += entrySize;
+            size++;
+        }
         messageList = messageList.subList(0, size);
         this.write((byte) size);
         for (AbstractMessage am : messageList) {


### PR DESCRIPTION
## Summary

Follow-up to #195.

Testing with more than 128 stored messages confirmed that the previous clamp prevents the client freeze, but can leave Messenger empty and prevent users from deleting old messages.

Messenger entries contain variable-length UTF-16 strings, so limiting only the entry count does not guarantee that the response fits the legacy 16 KiB packet boundary.

This change keeps the existing ascending-prefix behavior while:

- limiting the response to 127 entries
- stopping before the complete packet exceeds 16 KiB
- writing a count that matches the complete entries serialized

Only the existing game-server and chat-server packet serializers are changed.

## Validation

- full clean-checkout Maven reactor through game-server and chat-server: `BUILD SUCCESS`
- 7 existing tests passed
- direct decoded checks passed against both serializers for list types 0–3
- 129-message histories serialize IDs 1–127; after deleting two, IDs 3–129 become visible
- message and gift fields, FILETIME, sent/received names, seen state and product index decode correctly
- non-BMP UTF-16LE names and messages preserve exact byte accounting
- an exact 16,384-byte frame is accepted; the first entry beyond it produces a valid empty frame
- cumulative payload limits contain only complete bodies with matching count and header length
- `git diff --check` passed