### PR TITLE
fix(relationship): clear both players' couple state after breakup

### DIFF
--- a/chat-server/src/main/java/com/jftse/emulator/server/core/life/item/special/CoupleRing.java
+++ b/chat-server/src/main/java/com/jftse/emulator/server/core/life/item/special/CoupleRing.java
@@ -69,6 +69,7 @@ public class CoupleRing extends BaseItem {
 
         S2CYouBrokeUpWithYourCoupleAnswer brokeUpWithYourCoupleAnswer = new S2CYouBrokeUpWithYourCoupleAnswer();
         this.packetsToSend.add(this.localPlayerId, brokeUpWithYourCoupleAnswer);
+        this.packetsToSend.add(this.playerCoupleId, brokeUpWithYourCoupleAnswer);
 
         int newGold = player.getGold() - 20000;
         player.syncGold(newGold);

--- a/chat-server/src/main/java/com/jftse/emulator/server/core/rabbit/handlers/PacketOnlyHandler.java
+++ b/chat-server/src/main/java/com/jftse/emulator/server/core/rabbit/handlers/PacketOnlyHandler.java
@@ -26,6 +26,11 @@ public class PacketOnlyHandler extends AbstractMessageHandler<PacketMessage> {
     public void handle(PacketMessage message) {
         final FTConnection connection = gameManager.getConnectionByPlayerId(message.getReceivingPlayerId());
         if (connection != null) {
+            if (message.getPacketId() == PacketOperations.S2CYouBrokeUpWithYourCoupleAnswer.getValue()) {
+                connection.getClient().getPlayer().setCoupleId(null);
+                connection.getClient().getPlayer().setCoupleName("");
+            }
+
             connection.sendTCP(new Packet(message.getPacket()));
             log.info("Sent packet to player {}: {}", message.getReceivingPlayerId(), String.format("0x%X(%s)", message.getPacketId(), PacketOperations.getNameByValue(message.getPacketId())));
         }

--- a/game-server/src/main/java/com/jftse/emulator/server/core/life/item/special/CoupleRing.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/life/item/special/CoupleRing.java
@@ -69,6 +69,7 @@ public class CoupleRing extends BaseItem {
 
         S2CYouBrokeUpWithYourCoupleAnswer brokeUpWithYourCoupleAnswer = new S2CYouBrokeUpWithYourCoupleAnswer();
         this.packetsToSend.add(this.localPlayerId, brokeUpWithYourCoupleAnswer);
+        this.packetsToSend.add(this.playerCoupleId, brokeUpWithYourCoupleAnswer);
 
         int newGold = player.getGold() - 20000;
         player.syncGold(newGold);

--- a/game-server/src/main/java/com/jftse/emulator/server/core/rabbit/handlers/PacketOnlyHandler.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/rabbit/handlers/PacketOnlyHandler.java
@@ -26,6 +26,11 @@ public class PacketOnlyHandler extends AbstractMessageHandler<PacketMessage> {
     public void handle(PacketMessage message) {
         final FTConnection connection = gameManager.getConnectionByPlayerId(message.getReceivingPlayerId());
         if (connection != null) {
+            if (message.getPacketId() == PacketOperations.S2CYouBrokeUpWithYourCoupleAnswer.getValue()) {
+                connection.getClient().getPlayer().setCoupleId(null);
+                connection.getClient().getPlayer().setCoupleName("");
+            }
+
             connection.sendTCP(new Packet(message.getPacket()));
             log.info("Sent packet to player {}: {}", message.getReceivingPlayerId(), String.format("0x%X(%s)", message.getPacketId(), PacketOperations.getNameByValue(message.getPacketId())));
         }


### PR DESCRIPTION
## Context

Real-client breakup testing found a split state: the Couple Ring flow correctly transitioned both reciprocal `Friend` rows to ordinary friendship and refreshed messenger data, but online character profiles could continue showing the former partner until the affected session reloaded.

Relationship identity is cached in `FTPlayer.coupleId` and `FTPlayer.coupleName` following the [`6684529b77137b1412e72dc2d081e0a6667c18c0`](https://github.com/sstokic-tgm/JFTSE/commit/6684529b77137b1412e72dc2d081e0a6667c18c0) session-cache migration. `CoupleRing` updated persistence but did not invalidate those fields, and the existing breakup answer (`0x252A`) was queued only for the initiating player.

## Fix

- Queue the existing breakup answer for both partners.
- When either server delivers that answer to an online player, clear that player's cached couple ID and name before sending it to the client.

The existing quick-slot Rabbit flow already routes packets to both game and chat services. Updating the two mirrored delivery handlers therefore covers same-process and cross-process sessions without adding a message type or changing the relationship model.

The four touched files are two one-line `CoupleRing` changes and two identical five-line delivery guards. Gold, rings, friendship persistence, messenger refresh, and offline behavior remain unchanged.

## Real-client result

**Before:** the persisted breakup had completed, but QaShua's online profile still showed `Couple : QaLucy`.

![QaShua profile retaining stale couple state](https://ampcode.com/user-content/artifacts/d772280830bd0cc874e46175850b49ff21a1d28fdf78b95ae9b473c796269fee-file.png)

**After:** both online profiles cleared immediately, without relogging or changing rooms.

| Initiator | Partner |
| --- | --- |
| ![QaLucy profile cleared immediately](https://ampcode.com/user-content/artifacts/1a98365b981c27b7ffe798627f8b07dd21c560b96cc02dafcb0ac2f327680716-file.png) | ![QaShua profile cleared immediately](https://ampcode.com/user-content/artifacts/42b42b23a0c43da7d27e6c56d6e787ac87e75ea4f54a05d994c573eb891c8e2e-file.png) |

Verified through the real game-server breakup flow:

- Both reciprocal database rows became `EFriendshipState.Friends` (`1`).
- Both clients received the existing `0x252A` breakup answer and ring removal.
- Both profiles cleared immediately; messenger showed ordinary friendship.
- Couple rings were removed, a fresh room remained correct, and neither client disconnected.

Automated validation:

- `mvn -Dmaven.gitcommitid.skip=true -pl game-server,chat-server -am test`
- 7 tests passed; 0 failures or errors.
- `git diff --check` passed.

The game-server initiation path was exercised end to end. The mirrored chat-house initiation and a split game/chat placement were compiled but not independently replayed with real clients.
