### PR TITLE
fix(game): handle rooms without BattleMons

### DIFF
--- a/game-server/src/main/java/com/jftse/emulator/server/core/handler/matchplay/RoomStartGamePacketHandler.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/handler/matchplay/RoomStartGamePacketHandler.java
@@ -152,12 +152,12 @@ public class RoomStartGamePacketHandler implements PacketHandler<FTConnection, C
                                     c.getConnection().sendTCP(roomPlayerInformationPacket);
 
                                     for (RoomPlayer rp : filteredRoomPlayerList) {
-                                        short pos = rp.getPosition();
                                         PetView pet = rp.getPet();
-                                        byte slot = pos == 0 ? (byte) 0 : (byte) 1;
-
-                                        S2CPetRequestRoomAnswerPacket petRequestRoomAnswerPacket = new S2CPetRequestRoomAnswerPacket(S2CPetRequestRoomAnswerPacket.SUCCESS, true, slot, pet);
-                                        c.getConnection().sendTCP(petRequestRoomAnswerPacket);
+                                        if (pet != null) {
+                                            byte slot = rp.getPosition() == 0 ? (byte) 0 : (byte) 1;
+                                            S2CPetRequestRoomAnswerPacket petRequestRoomAnswerPacket = new S2CPetRequestRoomAnswerPacket(S2CPetRequestRoomAnswerPacket.SUCCESS, true, slot, pet);
+                                            c.getConnection().sendTCP(petRequestRoomAnswerPacket);
+                                        }
                                     }
                                 }
                             });

--- a/game-server/src/main/java/com/jftse/emulator/server/core/packets/lobby/room/S2CRoomPlayerListInformationPacket.java
+++ b/game-server/src/main/java/com/jftse/emulator/server/core/packets/lobby/room/S2CRoomPlayerListInformationPacket.java
@@ -19,6 +19,7 @@ public class S2CRoomPlayerListInformationPacket extends Packet {
         for (RoomPlayer roomPlayer : roomPlayerList) {
             EquippedItemParts equippedItemParts = roomPlayer.getEquippedItemPartsIDX();
             EquippedItemStats equippedItemStats = roomPlayer.getEquippedItemStats();
+            PetView pet = roomPlayer.getPet();
 
             boolean isSpectator = roomPlayer.getPosition() > 3;
             this.write(roomPlayer.getPosition());
@@ -30,7 +31,7 @@ public class S2CRoomPlayerListInformationPacket extends Packet {
             this.write(roomPlayer.isFitting());
             this.write((byte) roomPlayer.getPlayerType());
             this.write(isSpectator);
-            this.write((byte) 0); // read battlemon??
+            this.write(pet != null);
 
             GuildView guild = roomPlayer.getGuild();
             this.write(guild != null ? guild.name() : "");
@@ -111,7 +112,6 @@ public class S2CRoomPlayerListInformationPacket extends Packet {
             this.write(equippedItemParts.hat());
             this.write(equippedItemParts.dye());
 
-            PetView pet = roomPlayer.getPet();
             if (pet != null) {
                 this.write(pet.name());
                 this.write((byte) pet.level());
@@ -123,9 +123,6 @@ public class S2CRoomPlayerListInformationPacket extends Packet {
                 this.write((byte) pet.willpower());
                 this.write(pet.hunger());
                 this.write(pet.energy());
-            } else {
-                for (int i = 0; i < 10; i++)
-                    this.write(0);
             }
         }
     }


### PR DESCRIPTION
## Context

During a two-client real-client test of the couple lifecycle and Guardian couple bonus, both active players could ready normally but Guardian loading failed when neither player had a BattleMon selected. This was independent of relationship state.

The regression was introduced by [`fcdeb89a94bb17337f8b8f499b79c5892370004e`](https://github.com/sstokic-tgm/JFTSE/commit/fcdeb89a94bb17337f8b8f499b79c5892370004e), which added the optional BattleMon payload and match-start bootstrap.

The room packet still wrote a false presence byte for every player, then appended either a real BattleMon payload or ten 32-bit placeholder values. Match start also constructed a BattleMon packet when `PetView` was null. For a player without a BattleMon, that made the client's variable-length packet parsing lose alignment.

## Fix

- Write the BattleMon presence byte from `pet != null`.
- Write the BattleMon payload only when it exists; an absent optional value has no payload.
- Skip match-start BattleMon bootstrap packets for players without one.

No room, match, or BattleMon model behavior is otherwise changed.

## Real-client result

| Reproduction setup | After this fix |
| --- | --- |
| Two active no-BattleMon players ready for Guardian | Both players loaded and remained active in Guardian |
| ![QaLucy and QaShua ready before the failed load](https://ampcode.com/user-content/artifacts/ba1b4062bd60719ed6bf5b4b9a509b0c7cc4fac8053d64eab6e5352373840836-file.png) | ![QaLucy and QaShua together in Guardian after the fix](https://ampcode.com/user-content/artifacts/74441172dbd8f8f65527fb24e794aa9c09a56b7216c8d8a29270a9897c951ece-file.png) |

Verified with the real client:

- Two active players without BattleMons remained correctly visible in the room roster.
- Both loaded into the same Guardian match; neither was a spectator.
- No client crash or relationship-related disconnect occurred.
- The persisted-couple Guardian bonus from #200 still activated.

Automated validation:

- `mvn -Dmaven.gitcommitid.skip=true -pl game-server -am test`
- 7 tests passed; 0 failures or errors.
- `git diff --check` passed.

An equipped-BattleMon real-client control was not independently rerun. Its payload serialization is unchanged; this patch only makes its presence marker agree with that payload.
